### PR TITLE
Change include eeprom.h to lower case to make it compile on linux

### DIFF
--- a/mpguino_tav/mpguino_tav.ino
+++ b/mpguino_tav/mpguino_tav.ino
@@ -418,7 +418,7 @@ Logging Output / Debug Monitor I/O
 
 #include <avr/interrupt.h>
 #include <avr/pgmspace.h>
-#include <avr/EEPROM.h>
+#include <avr/eeprom.h>
 #include <avr/sleep.h>
 
 static const char titleMPGuino[] PROGMEM = {


### PR DESCRIPTION
Since Linux is case-sensitive the IDE doesn't find eeprom.h when capitalized. 