### PR TITLE
Fixed useChryslerMapCorrection

### DIFF
--- a/mpguino_tav/configs.h
+++ b/mpguino_tav/configs.h
@@ -15,7 +15,7 @@
 //   - useJSONoutput outputs selected trip functions as a JSON array of JSON objects
 //   - useDebugTerminal provides for a PC-MPGuino debugging environment to test various basic MPGuino functions
 //
-//#define useDataLoggingOutput true			// output 5 basic trip functions to a data logger or SD card, once every refresh period (0.5 second)
+#define useDataLoggingOutput true			// output 5 basic trip functions to a data logger or SD card, once every refresh period (0.5 second)
 //#define useJSONoutput true					// skybolt added to enable and call JSON out routine
 //#define useDebugTerminal true				// debugging terminal interface between PC and MPGuino
 //#define useBluetooth true					// bluetooth interface with Android phone
@@ -24,7 +24,7 @@
 //   - if useDataLoggingOutput is not selected, the below output port options will be ignored
 //   - if useDataLoggingOutput is selected, choose only one of the below output port options, or an error will result
 //
-//#define useLoggingSerialPort0 true			// select logging output on serial port channel 0 (most Arduino boards, excluding TinkerKit! LCD module)
+#define useLoggingSerialPort0 true			// select logging output on serial port channel 0 (most Arduino boards, excluding TinkerKit! LCD module)
 //#define useLoggingSerialPort1 true			// select logging output on serial port channel 1 (ATmega2560 board, Atmega32U4 board excluding TinkerKit! LCD module)
 //#define useLoggingSerialPort2 true			// select logging output on serial port channel 2 (ATmega2560 board)
 //#define useLoggingSerialPort3 true			// select logging output on serial port channel 3 (ATmega2560 board)
@@ -74,7 +74,7 @@
 //
 // if either useTinkerkitLCDmodule or useMPGuinoColourTouch is used, the below options will be ignored
 //
-//#define useLegacyLCD true					// select Legacy 16x2 4-bit LCD
+#define useLegacyLCD true					// select Legacy 16x2 4-bit LCD
 //#define useDFR0009LCD true						// (inw) select DFRobot DFR0009 LCD Keypad Shield
 //#define useAdafruitRGBLCDshield true		// select Adafruit RGB 16x2 4-bit LCD module over TWI
 //#define useParallaxSerialLCDmodule true		// select Parallax 16x2 Serial LCD module
@@ -103,7 +103,7 @@
 // note: if useAdafruitRGBLCDshield is selected, useLegacyButtons will be ignored
 //       if useMPGuinoColourTouch is selected, all hardware button choices will be ignored
 //
-//#define useLegacyButtons true
+#define useLegacyButtons true
 //#define useAnalogMuxButtons true
 //#define useParallax5PositionSwitch true
 
@@ -112,21 +112,21 @@
 #define trackIdleEOCdata true				// Ability to track engine idling and EOC modes
 #define useSavedTrips true					// Ability to save current or tank trips to EEPROM
 #define usePartialRefuel true				// Provide means to enter partial refuel amount into MPGuino
-//#define useFuelCost true					// Show fuel cost
-//#define useDragRaceFunction true			// Performs "drag race" 0-60 MPH, 1/4 mile time, estimated horsepower functionality
-//#define useBigFE true						// Show big fuel economy displays
-//#define useBigDTE true						// Show big distance-to-empty displays
-//#define useBigTTE true						// Show big time-to-empty displays
-//#define useBarFuelEconVsTime true			// Show Fuel Economy over Time bar graph
-//#define useBarFuelEconVsSpeed true			// Show Fuel Economy vs Speed, Fuel Used vs Speed bar graphs
-//#define useStatusMeter true					// displays a graphical meter for use with MPG display
-//#define useSpiffyTripLabels true			// Ability to use enhanced trip labels on main display screens
+#define useFuelCost true					// Show fuel cost
+#define useDragRaceFunction true			// Performs "drag race" 0-60 MPH, 1/4 mile time, estimated horsepower functionality
+#define useBigFE true						// Show big fuel economy displays
+#define useBigDTE true						// Show big distance-to-empty displays
+#define useBigTTE true						// Show big time-to-empty displays
+#define useBarFuelEconVsTime true			// Show Fuel Economy over Time bar graph
+#define useBarFuelEconVsSpeed true			// Show Fuel Economy vs Speed, Fuel Used vs Speed bar graphs
+#define useStatusMeter true					// displays a graphical meter for use with MPG display
+#define useSpiffyTripLabels true			// Ability to use enhanced trip labels on main display screens
 #define useSpiffyBigChars true				// Provides better number font with use with big number displays above
-//#define useScreenEditor true				// Ability to change any of (9 or 12, depending on configuration) existing trip data screens, with 4 configurable figures on each screen
-//#define useSoftwareClock true				// Shows 24 hour clock driven off of timer0, and provides a means to set it
+#define useScreenEditor true				// Ability to change any of (9 or 12, depending on configuration) existing trip data screens, with 4 configurable figures on each screen
+#define useSoftwareClock true				// Shows 24 hour clock driven off of timer0, and provides a means to set it
 //#define useCPUreading true					// Show CPU loading and available RAM usage
-//#define useChryslerMAPCorrection true		// Ability to perform on-the-fly fuel injector data correction for late-model Chrysler vehicles
-//#define useChryslerBaroSensor true			// allows use of a separate MAP sensor wired to MPGuino to read barometric pressure, for even more accurate correction
+#define useChryslerMAPCorrection true		// Ability to perform on-the-fly fuel injector data correction for late-model Chrysler vehicles
+#define useChryslerBaroSensor true			// allows use of a separate MAP sensor wired to MPGuino to read barometric pressure, for even more accurate correction
 //#define useOutputPins true					// Generate analog 0-5VDC output voltage on expansion pins to drive LEDs or feed signal to external gauges
 //#define blankScreenOnMessage true			// Completely blank display screen upon display of status message
 //#define useImperialGallon true				// when selected, uses Imperial gallons instead of default US gallons

--- a/mpguino_tav/mpguino_tav.ino
+++ b/mpguino_tav/mpguino_tav.ino
@@ -418,7 +418,7 @@ Logging Output / Debug Monitor I/O
 
 #include <avr/interrupt.h>
 #include <avr/pgmspace.h>
-#include <avr/EEPROM.h>
+#include <avr/eeprom.h>
 #include <avr/sleep.h>
 
 static const char titleMPGuino[] PROGMEM = {

--- a/mpguino_tav/trip_measurement.h
+++ b/mpguino_tav/trip_measurement.h
@@ -434,13 +434,6 @@ static const char pressureCorrectDisplayTitles[] PROGMEM = {
 	"Pressures" tcEOS
 };
 
-static const uint16_t pressureCorrectPageFormats[4] PROGMEM = {
-	 ((mpMAPpressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)		// Pressures
-	,((mpBaroPressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)
-	,((mpFuelPressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)
-	,((mpInjPressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)
-};
-
 #endif // defined(useChryslerMAPCorrection)
 #if defined(useEnhancedTripReset)
 namespace tripSave /* Trip save/restore/reset display support section prototype */

--- a/mpguino_tav/trip_measurement.ino
+++ b/mpguino_tav/trip_measurement.ino
@@ -666,49 +666,11 @@ static void tripSupport::resetWindowFilter(void)
 #if defined(useChryslerMAPCorrection)
 /* Chrysler returnless fuel pressure correction display section */
 
-static const uint8_t prgmCalculateMAPpressure[] PROGMEM = {
-	instrLdRegVoltage, 0x02, analogMAPchannelIdx,		// load analog channel ADC step value
-	instrSubMainFromX, 0x02, mpAnalogMAPfloorIdx,		// is reading below MAP sensor voltage floor?
-	instrBranchIfLT, 3,									// if not, continue
-	instrLdRegByte, 0x02, 0,							// zero out result in register 2
-
-//cont1:
-	instrMul2byMain, mpAnalogMAPnumerIdx,				// perform conversion to get pressure units per volts value
-	instrDiv2byMain, mpAnalogMAPdenomIdx,				// divide by pressure units per volts value
-	instrAddEEPROMtoX, 0x02, pMAPsensorOffsetIdx,		// add pressure offset value from EEPROM
-	instrStRegMain, 0x02, mpMAPpressureIdx,				// store resulting MAP sensor reading
-#if defined(useChryslerBaroSensor)
-	instrDone											// exit to caller
-};
-
-static const uint8_t prgmCalculateBaroPressure[] PROGMEM = {
-	instrLdRegVoltage, 0x02, analogBaroChannelIdx,		// load analog channel ADC step value
-	instrSubMainFromX, 0x02, mpAnalogBaroFloorIdx,		// is reading below barometric sensor voltage floor?
-	instrBranchIfLT, 3,									// if not, continue
-	instrLdRegByte, 0x02, 0,							// zero out result in register 2
-
-//cont1:
-	instrMul2byMain, mpAnalogBaroNumerIdx,				// convert to obtain pressure units per volts value
-	instrDiv2byMain, mpAnalogBaroDenomIdx,				// divide by pressure units per volts value
-	instrAddEEPROMtoX, 0x02, pBaroSensorOffsetIdx,		// add pressure offset value from EEPROM
-	instrStRegMain, 0x02, mpBaroPressureIdx,			// store resulting barometric sensor reading
-#endif // defined(useChryslerBaroSensor)
-	instrLdRegMain, 0x02, mpFuelPressureIdx,			// get fuel system differential pressure
-	instrAddMainToX, 0x02, mpBaroPressureIdx,			// add to reference barometric pressure to get fuel system absolute pressure
-	instrSubMainFromX, 0x02, mpMAPpressureIdx,			// subtract MAP to get differential pressure across the fuel injector
-	instrStRegMain, 0x02, mpInjPressureIdx,				// store differential pressure across the fuel injector
-	instrMul2byConst, idxCorrectionFactor2,				// set up for iSqrt
-	instrDiv2byMain, mpFuelPressureIdx,					// divide by the fuel system differential pressure
-	instrTestReg, 0x02,									// test whether overflow occurred
-	instrBranchIfOverflow, 6,							// if overflow occurred, go handle it
-	instrIsqrt, 0x02,									// perform square root on result
-	instrStRegVolatile, 0x02, vInjectorCorrectionIdx,	// save square root of presssure differential ratio as fuel injector correction factor
-	instrDone,											// return to caller
-
-//cont3:
-	instrLdRegConst, 0x02, idxCorrectionFactor,
-	instrStRegVolatile, 0x02, vInjectorCorrectionIdx,	// save initial injector correction index for pressure differential calculation
-	instrDone											// return to caller
+static const uint16_t pressureCorrectPageFormats[4] PROGMEM = {
+	 ((mpMAPpressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)		// Pressures
+	,((mpBaroPressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)
+	,((mpFuelPressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)
+	,((mpInjPressureIdx - mpMAPpressureIdx) << 8 ) |	(tPressureChannel)
 };
 
 static uint8_t pressureCorrect::displayHandler(uint8_t cmd, uint8_t cursorPos)


### PR DESCRIPTION
ChryslerMapCorrection was broken when refactoring code in commit 419973f (Jun-6-2023). Code that used to be in functions.h got moved to trip_measurement.ino, and code that used to be in trip_measurement.ino got moved to trip_measurement.h. Moving them back allows useChryslerMapCorrection to compile.

I also changed EEPROM.h to eeprom.h to allow compiling on linux.

What caused useChryslerMapCorrection to break:
The code from functions.h was moved to trip_measurement.ino, which caused "error: 'prgmCalculateMAPpressure' was not declared in this scope" because the IDE couldn't access those function definitions ("#include functions.h" in mpguino_tav.ino).
The code from trip_measurement.ino was moved to trip_measurement.h, causing "Compilation error: 'tPressureChannel' was not declared in this scope".