### PR TITLE
Checkpoint: SWEET64 assembler, debug monitor refactor, TFT board support

### DIFF
--- a/DEVELOPER_MANUAL.md
+++ b/DEVELOPER_MANUAL.md
@@ -44,6 +44,8 @@ Design goals:
 - **Metric/SAE branches** - a single program handles both unit systems via either conditional branches, or instructions that automatically fetch values based on the EEPROM metric mode parameter.
 - **Traceability** - when the debug terminal is compiled in, every instruction can be listed or single-stepped with register dumps.
 
+Historical Note - SWEET64 evolved into its present form, initially from noticing multiple different display calculations began requiring similar 64-bit arithmetic sequences, and then after new features added required 64-bit precision for intermediate math steps even if their output was 32-bit precision or less.
+
 ---
 
 ## 2. Virtual Machine Architecture
@@ -65,6 +67,15 @@ SWEET64 has **5 general-purpose 64-bit registers** (r1–r5), plus 2 additional 
 Instruction operands that refer to two registers use a packed hex byte `0xYX`, where X is the destination (rX) and Y is the source (rY). Example: `instrLdReg, 0x21` loads r1 into r2.
 
 All 64-bit registers are stored in the global array `uint64_t s64reg[]`.
+
+Why 64-bit Registers? Many MPGuino calculations involve multiplying large accumulated values by conversion factors.
+
+Examples:
+
+    Injector microseconds × 3785411784
+    Distance pulses × 1609344
+
+32-bit intermediates overflow during these operations, even though the final displayed result may fit in 32 bits. SWEET64 therefore performs calculations using 64-bit intermediates and returns the lower 32 bits of the final result.
 
 ### 2.2 8-bit Internal Registers
 
@@ -146,7 +157,7 @@ If `trackIdleEOCdata` is selected as a compile-time program option, the followin
 
 | Slot | Meaning |
 |---|---|
-| `eocIdleInstantIdx` | Last sample period only (or window-filtered average) |
+| `eocIdleInstantIdx` | Last sample period only |
 | `eocIdleCurrentIdx` | Running total since last current-trip reset |
 | `eocIdleTankIdx` | Running total since last tank reset / fill-up |
 
@@ -814,6 +825,22 @@ Trace output is written to the debug terminal in real time as the program execut
 ## 13. RAM Program Assembler
 
 Requires `useSWEET64RAMprograms` (auto-enabled with `useDebugTerminalSWEET64` on ATmega2560).
+
+The RAM assembler exists to permit rapid development and testing of SWEET64 programs without having to recompile and reflash MPGuino.
+
+Typical workflow:
+
+    Copy existing program
+    Modify instruction or instructions
+    Enable override
+    Test
+    Revise as necessary
+    Retest as necessary
+    Export as source
+
+This significantly reduces iteration time when developing or debugging SWEET64 code.
+
+The RAM assembler also permits more accurate determination of conditional branch instruction offset values, which would otherwise have to be figured out by hand. This eliminates a source of bugs.
 
 The assembler provides an interactive text-based environment to write, edit, and run SWEET64 programs without recompiling. Programs are assembled into the 256-byte `s64programRAM[]` buffer.
 

--- a/DEVELOPER_MANUAL.md
+++ b/DEVELOPER_MANUAL.md
@@ -27,6 +27,8 @@
 
 - [Appendix A: Quick Reference - Instruction Aliases](#appendix-a-quick-reference--instruction-aliases)
 - [Appendix B: Key `configs.h` Flags for Developers](#appendix-b-key-configsh-flags-for-developers)
+- [Appendix C: ATmega328P Debug Monitor (`useAtMega328debugMonitor`)](#appendix-c-atmega328p-debug-monitor-useatmega328debugmonitor)
+- [Appendix D: Second Arduino Uno as External Signal Generator](#appendix-d-second-arduino-uno-as-external-signal-generator)
 
 ---
 
@@ -630,7 +632,7 @@ On ATmega2560, the following are automatically enabled when `useDebugTerminal` i
 #define useBuffering true
 ```
 
-On ATmega328P, `useDebugTerminal` is silently disabled (too little flash).
+On ATmega328P, `useDebugTerminal` is normally silently disabled (too little flash). See [Appendix C](#appendix-c-atmega328p-debug-monitor-useatmega328debugmonitor) for the dedicated 328P debug monitor build.
 
 ### 10.2 Connecting
 
@@ -753,7 +755,15 @@ These operations use SWEET64 internally (registers r6/r7 are the debug terminal'
 
 ### 11.11 System Status (`^S`)
 
-`^S` means Ctrl-S. It prints a compact system snapshot, including uptime, clock time when `useClockDisplay` is enabled, decimal-format settings, decoded status flags, raw status bytes, SWEET64 RAM override status when enabled, the SWEET64 error latch when enabled, and Bluetooth response state when the BLE shield support is compiled in.
+`^S` means Ctrl-S. It prints a compact system snapshot, including uptime when CPU/debug CPU timing support is compiled in, clock time when `useClockDisplay` is enabled, decimal-format settings, decoded status flags, raw status bytes, SWEET64 RAM override status when enabled, the SWEET64 error latch when enabled, and Bluetooth response state when the BLE shield support is compiled in.
+
+With `useDebugTerminalSWEET64`, the SWEET64 error latch reports the last engine-detected malformed-program error:
+
+```
+S64 ERR count=0027 @ 02R last=03 bad reg operand
+```
+
+The count increments when the same error repeats at the same SWEET64 program counter. A different error or different program counter resets the count to 1. The `N` command toggles SWEET64 error mute; while muted, repeated runtime error reports are suppressed, but the latch and count remain visible through `^S`.
 
 ### 11.12 Help (`?`)
 
@@ -810,15 +820,18 @@ Output shows both the raw 64-bit hex value and a formatted decimal representatio
 |---|---|
 | `x^T` | Trace function `x` for 1 instruction, dump state |
 | `x.y^T` | Trace function `x` for `y` instructions (`y=0` = run to completion) |
+| `z<y^T` | Trace RAM program at address `z` for `y` instructions (`y=0` = run to completion; requires `useSWEET64RAMprograms`) |
 
 Each traced instruction line shows:
 - Program counter (address)
 - Opcode name
 - Operands (symbolic if labels enabled)
-- Post-execution register file dump
-- Flags (C Z M V E)
+- Post-execution register file dump when trace remains active
+- Decoded SWEET64 flags, including carry, zero, minus, overflow, error, and trace state
 
 Trace output is written to the debug terminal in real time as the program executes.
+
+If a malformed instruction or bad operand is encountered, the trace stops, the SWEET64 error latch is updated, and the terminal prints the error report unless SWEET64 errors are muted with `N`.
 
 ---
 
@@ -902,7 +915,7 @@ Disassembles program RAM starting at address `x`, printing instructions in the s
 z<y^T
 ```
 
-Traces the RAM program starting at address `z`, for `y` instructions (`y=0` = run to completion).
+Traces the RAM program starting at address `z`, for `y` instructions (`y=0` = run to completion). This uses the same trace engine as function tracing, so invalid RAM opcodes, missing operands, stack overflow, and bad operand errors are reported through the SWEET64 error latch.
 
 ### 13.6 Export as C Source (`^W`)
 
@@ -945,7 +958,7 @@ When an error is detected, `SWEET64errorFlag` is set in `si64reg8flags` and an e
 | `s64errStackOverflow` | 8 | Call depth exceeded 16 |
 | `s64errBadOperand` | 9 | General operand validation failure |
 
-The debug terminal displays these symbolically in trace/error output. In production builds (no debug terminal), execution simply stops at the bad instruction and returns whatever is in r2.
+The debug terminal displays these symbolically in trace/error output and through the `^S` SWEET64 error latch. In production builds (no debug terminal), execution simply stops at the bad instruction and returns whatever is in r2.
 
 ---
 
@@ -1097,7 +1110,120 @@ At 31,373 Hz, a modest RC filter (e.g. 10 kΩ + 100 nF, f_RC ≈ 160 Hz) provide
 | `useDebugButtonInjection` | `I` command (requires `useDebugTerminal` + buttons) |
 | `useDebugCPUreading` | Fine-grained interrupt-level CPU counters |
 | `useSimulatedFIandVSS` | `S` command + injector/VSS simulation |
+| `useAtMega328debugMonitor` | Dedicated debug monitor build for ATmega328P |
 | `useActivityLED` | On-board LED phase indicator |
+
+---
+
+## Appendix C: ATmega328P Debug Monitor (`useAtMega328debugMonitor`)
+
+### C.1 Purpose
+
+`useAtMega328debugMonitor` is a special build configuration that enables a headless SWEET64 debug terminal on an Arduino Uno (ATmega328P). Normally `useDebugTerminal` is suppressed on 328P due to flash constraints (32256 bytes usable with Optiboot bootloader). This flag overrides that suppression and simultaneously strips out enough non-essential features to make the terminal fit.
+
+It is intended as a dedicated development and SWEET64 debugging firmware — not a configuration that would be used in a vehicle.
+
+### C.2 Enabling
+
+This configuration has been compile/upload tested on both Arduino Uno and Arduino Mega2560 hardware. The Mega2560 build can be useful for testing the same monitor personality with more flash headroom, while the Uno build proves the minimum dev-console target still fits.
+
+In `configs.h`, set only this flag:
+
+```c
+#define useAtMega328debugMonitor true
+```
+
+Everything else is configured automatically by the monitor block in `configs.h`. No other flags need to be set or cleared manually.
+
+### C.3 What the Monitor Block Enables
+
+```c
+#define useDebugTerminal true
+#define useDebugTerminalHelp true        // see flash budget notes below
+#define useDebugTerminalLabels true      // symbolic names in output
+#define useDebugTerminalSWEET64 true     // ^L, ^T, ^I, ^F, ^E commands
+#define useSWEET64RAMprograms true       // RAM assembler
+#define useDebugTerminalSerialPort0 true // UART0 (pins 0/1)
+```
+
+On Mega2560, the same monitor block also enables `useDebugCPUreading`. On ATmega328P, `useDebugCPUreading` is disabled to preserve flash for the SWEET64 monitor and RAM-program tools.
+
+### C.4 What the Monitor Block Disables
+
+To fit within the 328P flash budget, the monitor block disables all display hardware, button input, clocks, drag race, bar graphs, signal simulation, and other peripherals that are irrelevant to a headless debug session. Key items disabled include `useSimulatedFIandVSS`, `useSoftwareClock`, `useDS1307clock`, `useOutputPins`, `useDragRaceFunction`, all LCD/display options, all button options, Bluetooth/JSON/logging outputs, and board-specific display defines.
+
+### C.5 Flash Budget and Feature Tradeoffs
+
+The 32256-byte usable flash is tight. Representative sizes for key feature combinations:
+
+| Configuration | Flash used |
+|---|---|
+| Labels only, no help text | ~29728 bytes |
+| Labels + help text (attenuated for 328P) | ~32100 bytes |
+| Labels + help text + `useSimulatedFIandVSS` | ~34500 bytes |
+
+The help text in `terminalHelp` uses run-length encoding for space characters (`\x01\xNN` expands to N spaces in `text::stringOut`) to reduce flash consumption. For the 328P monitor build, the accumulator math operation entries and the decimal sample output (`U`) command entry are additionally omitted from the help text since they are straightforward enough to use without inline documentation.
+
+The status and trace code is also arranged so the headless monitor can inspect core runtime state without pulling in the LCD/button-facing screens. `^S` remains available for decoded activity/status bytes and SWEET64 error state; uptime appears only when CPU/debug CPU timing support is included.
+
+`useSimulatedFIandVSS` does not fit alongside the full debug terminal on 328P. Use a second Arduino Uno as an external signal generator instead — see [Appendix D](#appendix-d-second-arduino-uno-as-external-signal-generator).
+
+### C.6 Serial Connection
+
+Connect to UART0 (pin 1 = TX, pin 0 = RX) at the configured baud rate, 8N1. The USB-to-serial converter on the Uno board makes this straightforward — use the Arduino IDE Serial Monitor or any terminal program with CR or CR+LF line endings.
+
+### C.7 Primary Workflow
+
+The 328P monitor is meant to support SWEET64 development without an LCD:
+
+1. Use `^F`, `^I`, and `^L` to inspect existing SWEET64 functions.
+2. Use `x<yM` to copy a flash function into program RAM.
+3. Use `x!` to assemble or patch instructions in RAM.
+4. Use `z<y^T` to trace the RAM program.
+5. Use `x<y^O` to substitute the RAM program for an existing function.
+6. Use `x.y^W` to export the RAM program as paste-ready C source once the behavior is correct.
+
+The same workflow works on Mega2560, but the Uno build is the useful proof that SWEET64 bytecode can be developed on a cheap standalone board.
+
+---
+
+## Appendix D: Second Arduino Uno as External Signal Generator
+
+### D.1 Why
+
+`useSimulatedFIandVSS` — the built-in signal simulator — does not fit in the 328P flash alongside `useAtMega328debugMonitor`. A second Uno running dedicated signal-generation firmware is a cleaner solution in any case: it exercises the real hardware interrupt path rather than software-injected signals, and it keeps the device under test running exactly the firmware under development.
+
+### D.2 Signal Characteristics
+
+MPGuino expects two input signals:
+
+**VSS (vehicle speed sensor):**
+- A square wave on the VSS interrupt pin
+- Frequency proportional to simulated vehicle speed
+- Pulse width is not critical; a 50% duty cycle square wave works
+
+**Fuel injector:**
+- A pulse train on the injector interrupt pin
+- Edge polarity must match `pInjEdgeTriggerIdx`
+- The default saturated-injector setting treats falling edge as injector open and rising edge as injector close
+- Pulse width proportional to simulated fuel flow
+- Frequency should match simulated engine RPM
+
+Both signals are measured in Timer0 cycles by the MPGuino ISRs. Refer to the `idxTicks0PerSecond` and `idxCycles0PerSecond` constant table entries (§7) for the timer rate.
+
+### D.3 Connections
+
+| Signal | Generator Uno pin | MPGuino Uno pin |
+|---|---|---|
+| VSS | Any digital output | VSS interrupt input |
+| Injector | Any digital output | Injector interrupt input |
+| GND | GND | GND |
+
+A common ground between the two boards is required.
+
+### D.4 Generator Sketch
+
+A minimal generator sketch uses `tone()` or Timer1 to produce the VSS square wave, and a separate timer or `analogWrite()` channel for the injector pulse train. The exact frequencies needed depend on the VSS pulses-per-mile parameter stored in MPGuino's EEPROM and the injector flow rate parameter — set these in the MPGuino EEPROM via the `P` command first, then size the generator frequencies to produce the desired simulated speed and fuel flow.
 
 ---
 

--- a/DEVELOPER_MANUAL.md
+++ b/DEVELOPER_MANUAL.md
@@ -1,4 +1,4 @@
-# MPGuino v1.95tav — Developer Manual
+# MPGuino v1.95tav - Developer Manual
 ## SWEET64 Engine & Debug Terminal
 
 **Version:** 1.95tav  
@@ -23,6 +23,10 @@
 13. [RAM Program Assembler](#13-ram-program-assembler)
 14. [SWEET64 Error Codes](#14-sweet64-error-codes)
 15. [CPU Loading & Activity LED](#15-cpu-loading--activity-led)
+16. [Hardware Timer Architecture](#16-hardware-timer-architecture)
+
+- [Appendix A: Quick Reference - Instruction Aliases](#appendix-a-quick-reference--instruction-aliases)
+- [Appendix B: Key `configs.h` Flags for Developers](#appendix-b-key-configsh-flags-for-developers)
 
 ---
 
@@ -30,14 +34,15 @@
 
 SWEET64 is a compact bytecode interpreter for 64-bit arithmetic, inspired by Steve Wozniak's SWEET16 (1977). Its purpose is to perform multi-step 64-bit calculations without the ROM overhead of inlining AVR assembly or C code for each formula.
 
-Every display value MPGuino shows — fuel economy, speed, distance, time to empty, engine power — is calculated by a SWEET64 program. Each program lives in AVR flash (`PROGMEM`) as a `static const uint8_t prgmXxx[] PROGMEM = { ... }` array and is invoked by the display or logging layer.
+Every display value MPGuino shows - fuel economy, speed, distance, time to empty, engine power - is calculated by a SWEET64 program. Each program lives in AVR flash (`PROGMEM`) as a `static const uint8_t prgmXxx[] PROGMEM = { ... }` array and is invoked by the display or logging layer.
 
 Design goals:
-- **Dense encoding** — most instructions are 1–4 bytes.
-- **64-bit registers** — avoids overflow in intermediate products (e.g. `µs × 3785411784` for volume conversion).
-- **Direct access** to EEPROM parameters, trip accumulators, and program variables without C function calls.
-- **Metric/SAE branches** — a single program handles both unit systems via conditional branches.
-- **Traceability** — when the debug terminal is compiled in, every instruction can be listed or single-stepped with register dumps.
+- **Speed** - about 95% as fast as a coded function written in pure C.
+- **Dense encoding** - most instructions are 1–4 bytes.
+- **64-bit registers** - avoids overflow in intermediate products (e.g. `µs × 3785411784` for volume conversion).
+- **Direct access** to EEPROM parameters, trip accumulators, main program variables, and interrupt-visible program variables without C function calls.
+- **Metric/SAE branches** - a single program handles both unit systems via either conditional branches, or instructions that automatically fetch values based on the EEPROM metric mode parameter.
+- **Traceability** - when the debug terminal is compiled in, every instruction can be listed or single-stepped with register dumps.
 
 ---
 
@@ -106,6 +111,59 @@ A single 8-bit primary index (`si64reg8trip` is repurposed in some operations) c
 ### 2.6 Jump Register
 
 `si64reg8jump` holds an index value for `instrCallImplied` (indirect call). Loaded by `instrLdJumpReg`.
+
+### 2.7 Trip Variables
+
+Trip variables are the ISR-maintained accumulator arrays that hold every raw measurement MPGuino collects. They are one of SWEET64's three primary data sources alongside EEPROM parameters and program variables.
+
+#### Measured fields (`rv*Idx`)
+
+Each trip slot holds up to five fields (`trip_measurement.h`):
+
+| Index constant | Type | What it accumulates |
+|---|---|---|
+| `rvVSSpulseIdx` (0) | `uint32_t` | VSS pulse edges — the distance counter |
+| `rvVSScycleIdx` (1) | `uint64_t` | Timer0 cycles while vehicle was moving |
+| `rvInjPulseIdx` (2) | `uint32_t` | Injector pulse count — engine revolution proxy |
+| `rvInjCycleIdx` (3) | `uint64_t` | Timer0 cycles injector was open — the fuel counter |
+| `rvEngCycleIdx` (4) | `uint64_t` | Timer0 cycles engine was running |
+
+`rvVSSpulseIdx` and `rvInjCycleIdx` are used in every fuel-economy calculation: FE = `rvVSSpulseIdx` / `rvInjCycleIdx`, scaled by unit conversion constants. Not all fields exist in every slot — slots below `tripSlotFullCount` carry all five; slots from `tripSlotFullCount` to `tripSlotCount` carry only the first two, saving RAM for bar-graph history slots.
+
+`rvVSScycleIdx`, `rvInjCycleIdx`, and `rvEngCycleIdx` hold timer0 cycle counts, not milli- or microsecond values. This is to preserve the accuracy of the gathered time measurements for the trip variables.
+
+#### Trip slot indices
+
+Slots are allocated at compile time via a `#define nextAllowedValue` chain. The three slots used by almost all display programs:
+
+| Slot | Meaning |
+|---|---|
+| `instantIdx` | Last sample period only (or window-filtered average) |
+| `currentIdx` | Running total since last current-trip reset |
+| `tankIdx` | Running total since last tank reset / fill-up |
+
+If `trackIdleEOCdata` is selected as a compile-time program option, the following additional trip slots are allocated, and their meanings are slightly modified as compared to the above three slots. `rvVSSpulseIdx` and `rvVSScycleIdx` track vehicle movement while the engine is not detected to be running, while `rvInjPulseIdx`, `rvInjCycleIdx`, and `rvEngCycleIdx` collect engine run data while the vehicle is not detected as moving.
+
+| Slot | Meaning |
+|---|---|
+| `eocIdleInstantIdx` | Last sample period only (or window-filtered average) |
+| `eocIdleCurrentIdx` | Running total since last current-trip reset |
+| `eocIdleTankIdx` | Running total since last tank reset / fill-up |
+
+Additional optional slots: `dragHalfSpeedIdx/FullSpeedIdx/DistanceIdx` (`useDragRaceFunction`), `windowTripFilterIdx[0..3]` (`useWindowTripFilter`), bar-graph history buckets (`useBarFuelEconVsTime`, `useBarFuelEconVsSpeed`), and EEPROM mirror slots (`useEEPROMtripStorage`).
+
+#### Raw → processed pipeline
+
+The Timer0 ISR accumulates into one of two raw double-buffer slots (`raw0tripIdx` / `raw1tripIdx`, tracked by `curRawTripIdx`). At each sample tick (2× per second) the main loop atomically swaps the active raw slot, then propagates the old raw slot into the processed slots via `tripUpdateList[]`. Bit 7 of the destination index selects the operation: set = **transfer** (replace), clear = **accumulate** (add). This is how trip measurement accuracy is maintained with a minimum possible chance of a trip related measurement being missed or garbled.
+
+#### Accessing from SWEET64
+
+```
+instrLdRegTripVar,        0xXY, <tripIdx>, <rvFieldIdx>   // load from named slot
+instrLdRegTripVarIndexed, 0xXY, <rvFieldIdx>              // load using index register as slot
+```
+
+See §5.6 for the full trip variable instruction reference.
 
 ---
 
@@ -218,7 +276,7 @@ All instruction constants are defined in `sweet64.h`. The following is a complet
 | Instruction | Operands | Description |
 |---|---|---|
 | `instrTestReg` | `rX` (packed in high nibble of register byte) | Test r5 for zero / high bit |
-| `instrTestIndex` | — | Test primary index for zero / high bit |
+| `instrTestIndex` | - | Test primary index for zero / high bit |
 | `instrCmpXtoY` | `rX`, `rY` | Compare rX to rY; set flags |
 | `instrCmpIndex` | primary byte | Compare primary index to immediate byte |
 
@@ -228,7 +286,7 @@ All branches take a **1-byte signed relative offset** (added to PC after the bra
 
 | Instruction | Alias | Branches when… |
 |---|---|---|
-| `instrBranchIfVclear` | — | overflow clear |
+| `instrBranchIfVclear` | - | overflow clear |
 | `instrBranchIfVset` | `instrBranchIfOverflow` | overflow set |
 | `instrBranchIfMclear` | `instrBranchIfPlus` | minus clear (result ≥ 0) |
 | `instrBranchIfMset` | `instrBranchIfMinus` | minus set (result < 0) |
@@ -236,20 +294,20 @@ All branches take a **1-byte signed relative offset** (added to PC after the bra
 | `instrBranchIfZset` | `instrBranchIfE`, `instrBranchIfZero` | zero set (X == Y) |
 | `instrBranchIfCclear` | `instrBranchIfLTorE` | carry clear (X ≤ Y) |
 | `instrBranchIfCset` | `instrBranchIfGT` | carry set (X > Y) |
-| `instrBranchIfLT` | — | X < Y |
-| `instrBranchIfGTorE` | — | X ≥ Y |
-| `instrBranchIfMetricMode` | — | metric mode active |
-| `instrBranchIfSAEmode` | — | SAE (imperial) mode active |
-| `instrBranchIfFuelOverDist` | — | output format is fuel/distance (L/100km) |
-| `instrBranchIfDistOverFuel` | — | output format is distance/fuel (MPG or km/L) |
-| `instrSkip` | — | always branch (unconditional) |
+| `instrBranchIfLT` | - | X < Y |
+| `instrBranchIfGTorE` | - | X ≥ Y |
+| `instrBranchIfMetricMode` | - | metric mode active |
+| `instrBranchIfSAEmode` | - | SAE (imperial) mode active |
+| `instrBranchIfFuelOverDist` | - | output format is fuel/distance (L/100km) |
+| `instrBranchIfDistOverFuel` | - | output format is distance/fuel (MPG or km/L) |
+| `instrSkip` | - | always branch (unconditional) |
 
 ### 5.3 Subroutine / Jump
 
 | Instruction | Operands | Description |
 |---|---|---|
 | `instrCall` | function index byte | Push PC, call indexed trip function |
-| `instrCallImplied` | — | Push PC, call function in jump register |
+| `instrCallImplied` | - | Push PC, call function in jump register |
 | `instrJump` | function index byte | Jump to indexed trip function (no push) |
 | `instrLdJumpReg` | index byte | Load jump register from primary index |
 
@@ -276,7 +334,7 @@ All branches take a **1-byte signed relative offset** (added to PC after the bra
 | `instrLxdIEEPROM` | parmIdx | primary index ← EEPROM value at parmIdx |
 | `instrLxdIEEPROMoffset` | parmIdx | primary index ← EEPROM value at (parmIdx + index) |
 | `instrLxdIParamLength` | parmIdx | primary index ← bit-length of EEPROM parmIdx |
-| `instrLxdIParamLengthIndexed` | — | primary index ← bit-length of EEPROM param at index |
+| `instrLxdIParamLengthIndexed` | - | primary index ← bit-length of EEPROM param at index |
 | `instrAddIndex` | offset byte | primary index += (program byte + old index) |
 
 ### 5.6 Trip Variable Access
@@ -472,7 +530,7 @@ static const uint8_t prgmCalculateFuelEconomy[] PROGMEM = {
 
 **Rules:**
 1. The program **must end with `instrDone`**. Falling off the end is undefined behaviour.
-2. `r2` is the **return value** — `runPrgm()` returns `(uint32_t)(s64reg[s64reg64_2])` (lower 32 bits).
+2. `r2` is the **return value** - `runPrgm()` returns `(uint32_t)(s64reg[s64reg64_2])` (lower 32 bits).
 3. Branch offsets are **signed bytes relative to the byte immediately after the branch instruction**. Positive = forward, negative = backward.
 4. The trip index passed to `runPrgm()` is available in `si64reg8trip`; instructions like `instrLdRegTripVar` substitute this automatically when `tripIdx` is used as the trip operand.
 5. All EEPROM parameters are already scaled by ×1000 (the `idxDecimalPoint` convention). When presenting to users, the display layer divides by 1000 for the decimal point.
@@ -582,9 +640,9 @@ Commands are single characters, optionally preceded by numeric arguments separat
 [z]<[y].[x]CMD[:value] [value2] ...
 ```
 
-- `x` — primary argument (start index, address, etc.)
-- `y` — secondary argument (end index, destination, etc.)
-- `z` — tertiary argument (decimal window width, etc.)
+- `x` - primary argument (start index, address, etc.)
+- `y` - secondary argument (end index, destination, etc.)
+- `z` - tertiary argument (decimal window width, etc.)
 - Values after `:` are written to the target
 
 Numeric input is **hexadecimal by default**. Use `\` to switch the current number entry to decimal. Use `$` or `X` to switch back to hexadecimal.
@@ -667,14 +725,14 @@ These operations use SWEET64 internally (registers r6/r7 are the debug terminal'
 | `y<xR` | Copy trip slot `x` into trip slot `y` |
 | `R` | Copy any trip into the terminal trip variable |
 
-### 11.9 Signal Simulator (`S`) — requires `useSimulatedFIandVSS`
+### 11.9 Signal Simulator (`S`) - requires `useSimulatedFIandVSS`
 
 | Syntax | Description |
 |---|---|
 | `S` | List simulator modes |
 | `nS` | Set simulator mode `n` |
 
-### 11.10 Button Injection (`I`) — requires `useDebugButtonInjection`
+### 11.10 Button Injection (`I`) - requires `useDebugButtonInjection`
 
 | Syntax | Description |
 |---|---|
@@ -703,7 +761,7 @@ These commands require `useDebugTerminalSWEET64`. Commands shown with `^` use co
 | `^I` | List all opcodes and their operand descriptions |
 | `y.x^I` | List opcodes from `y` to `x` |
 
-### 12.2 Function Length Table (`^F`) — requires `useDebugTerminalLabels`
+### 12.2 Function Length Table (`^F`) - requires `useDebugTerminalLabels`
 
 | Syntax | Description |
 |---|---|
@@ -879,9 +937,9 @@ MPGuino measures its own CPU utilisation using timer0 cycle counts. In the main 
 Every sample tick (2× per second), the working counters are snapshotted into `m32CPUsampledXxx` for display, then reset.
 
 The **CPU Info** display screen shows:
-- `C%` — main process fraction as a percentage of total loop time
-- `T` — system uptime since power-on
-- `FREE RAM` — available SRAM (heap top to stack pointer distance)
+- `C%` - main process fraction as a percentage of total loop time
+- `T` - system uptime since power-on
+- `FREE RAM` - available SRAM (heap top to stack pointer distance)
 
 With `useDebugCPUreading`, the breakdown is finer: devices, activity, sample, output, other, and interrupt processing times each get their own counter.
 
@@ -904,7 +962,89 @@ Call `activityLED::assert(flag)` to set the LED for a phase and `activityLED::re
 
 ---
 
-## Appendix A: Quick Reference — Instruction Aliases
+## 16. Hardware Timer Architecture
+
+MPGuino relies on two AVR hardware timers for all time-critical internal functions. Understanding their roles is essential when modifying interrupt handlers, sleep behaviour, display timing, or output pin PWM.
+
+### 16.1 Timer0 - System Heartbeat
+
+Timer0 is MPGuino's primary timebase. It runs continuously at a fixed rate determined by the AVR clock and a prescaler of 64:
+
+```
+f_overflow = F_CPU / (prescaler × 256) = 16 MHz / (64 × 256) = 976 Hz
+```
+
+The overflow ISR (`TIMER0_OVF_vect`, `heart.ino`) is the heartbeat of the entire system. On every overflow it:
+
+- Counts VSS pulses and injector open-time cycles (the raw trip accumulators)
+- Manages the wake/sleep watchdog (see §16.3)
+- Drives the sampling ticker: every `delay0TickSampleLoop` overflows, sets `t0saTakeSample`, which tells the main loop to collect and snapshot trip data - this fires **twice per second** (`samplesPerSecond = 2`, `heart.h`)
+- Sets `t0saUpdateDisplay` to trigger a display refresh at the same rate
+- Manages LCD write-delay timing (`t0saDisplayDelayInit` / `t0saDisplayDelayActive`)
+- Toggles the cursor blink flag (`t0saShowCursor`)
+- Drives JSON data-logging output timing
+
+The `t0saTakeSample` and `t0saUpdateDisplay` flags in `v8Timer0Status0Idx` are the mechanism by which the ISR signals the main loop without blocking it; the main loop polls these flags and clears them after acting.
+
+`idxTicks0PerSecond` and `idxCycles0PerSecond` in the SWEET64 constant table expose the Timer0 rate to bytecode programs for time-based calculations (e.g. converting injector open cycles to fuel volume).
+
+### 16.2 Timer1 - Secondary Timer and PWM Source
+
+Timer1 runs in **8-bit phase-correct PWM mode with prescaler 1**, configured by `heart.ino`:
+
+```
+f_overflow = F_CPU / (2 × prescaler × TOP) = 16 MHz / (2 × 1 × 255) = 31,373 Hz
+```
+
+The overflow ISR (`TIMER1_OVF_vect`, `heart.ino`) fires at this rate and handles:
+
+- **LCD write delays** (`t1cDelayLCD`): precise inter-command timing for the LCD controller; the main loop busy-waits on this flag via `performSleepMode(SLEEP_MODE_IDLE)` rather than spinning
+- **Debug stopwatch** (`t1cEnableDebug`): accumulates Timer1 overflow counts into `v32WorkingTimer1Idx` for CPU interrupt-load measurement
+- **BLE keepalive**: re-enables the Timer1 interrupt when BLE activity requires it
+
+`idxCycles1PerTick = 510` and `idxTicks1PerSecond` in the SWEET64 constant table expose the Timer1 rate to bytecode programs (used by the signal simulator for injector pulse timing).
+
+Timer1's output compare units also drive PWM outputs:
+
+| MCU | Pin | Signal | Use |
+|---|---|---|---|
+| all | OC1A | LCD backlight brightness | `m_lcd.ino`, written via `OCR1A` |
+| ATmega328P | OC1B | EXP1 output pin | `feature_outputpin.ino`, written via `OCR1B` |
+
+Because the LCD backlight and EXP1 share Timer1, the 31,373 Hz PWM frequency is fixed by the timer configuration - it cannot be changed without affecting both functions simultaneously.
+
+### 16.3 Wake / Sleep Mechanism
+
+MPGuino can enter AVR sleep mode to reduce power consumption when the vehicle is not in use. The wake state is tracked in `v8AwakeIdx` using three independent flags:
+
+| Flag | Set when | Cleared when |
+|---|---|---|
+| `aAwakeOnInjector` | Injector pulse detected | No injector activity for timeout period |
+| `aAwakeOnVSS` | VSS pulse detected | No VSS pulses for timeout period |
+| `aAwakeOnInput` | Button pressed | Activity timeout expires |
+
+The **activity timeout** watchdog counter (`activityTimeoutCount`) is decremented on every Timer0 overflow. It is reset to `v16ActivityTimeoutIdx` whenever relevant activity is detected. When it reaches zero, the corresponding awake flag is cleared.
+
+MPGuino enters `SLEEP_MODE_IDLE` (Timer0 and Timer1 still running) during idle periods in the main loop via `heart::performSleepMode()`. This keeps the ISRs active while halting the CPU, saving power between events.
+
+### 16.4 Output Pin PWM Frequencies
+
+The EXP1 and EXP2 expansion output pins use hardware PWM for DAC-style analog output (PWM → RC low-pass filter → 0–5 V). The frequencies by MCU are:
+
+| MCU | Timer | Pin | Mode | Prescaler | f_PWM |
+|---|---|---|---|---|---|
+| ATmega328P | Timer1 | EXP1 (OC1B) | Phase-correct 8-bit | 1 | 31,373 Hz |
+| ATmega328P | Timer2 | EXP2 (OC2A) | Phase-correct 8-bit | 1 | 31,373 Hz |
+| ATmega2560 | Timer5 | EXP1 (OC5A) + EXP2 (OC5B) | Phase-correct 8-bit | 64 | 490 Hz |
+| ATmega32U4 | Timer4 | EXP1 (OC4A) + EXP2 (OC4D) | Set by Arduino core | board-specific | - |
+
+On ATmega328P, Timer2 is explicitly configured to phase-correct 8-bit PWM with prescaler 1 in `outputPin::init()`, overriding the Arduino core's default of fast PWM / prescaler 64 (~977 Hz). This ensures both EXP pins run at the same frequency and can share a single RC filter design.
+
+At 31,373 Hz, a modest RC filter (e.g. 10 kΩ + 100 nF, f_RC ≈ 160 Hz) provides approximately 200:1 attenuation of PWM ripple, leaving under 0.5% residual ripple on the analog output.
+
+---
+
+## Appendix A: Quick Reference - Instruction Aliases
 
 ```cpp
 #define instrBranchIfOverflow       instrBranchIfVset

--- a/archive_pre_github/README.md
+++ b/archive_pre_github/README.md
@@ -1,0 +1,5 @@
+# MPGuino v1.95tav - code archive
+
+This directory contains all of the code changes I performed, beginning with a small optimization of DCB's existing code, leading up to when I transitioned to GitHub for storing my repository.
+
+GPL — see [LICENSE](LICENSE).

--- a/mpguino_tav/configs.h
+++ b/mpguino_tav/configs.h
@@ -18,7 +18,8 @@
 //
 //#define useDataLoggingOutput true			// output 5 basic trip functions to a data logger or SD card, once every refresh period (0.5 second)
 //#define useJSONoutput true					// skybolt added to enable and call JSON out routine
-#define useDebugTerminal true				// debugging terminal interface between PC and MPGuino
+#define useDebugTerminal true				// debugging terminal interface between PC and MPGuino - recommended for use with Mega2560
+#define useAtMega328debugMonitor true		// PC-only Arduino UNO R3 debugging terminal interface between PC and MPGuino
 //#define useBluetooth true					// bluetooth interface with Android phone
 
 // logging output port options
@@ -63,7 +64,7 @@
 //
 // Debug terminal serial output settings - if the corresponding serial output port is not selected, these will be ignored
 //
-#define useDebugTerminalBufferedOutput true	// speed up debug terminal output on serial port
+//#define useDebugTerminalBufferedOutput true	// speed up debug terminal output on serial port
 #define useDebugTerminalSerialBaudRate 38400
 
 // Bluetooth output port options
@@ -199,6 +200,91 @@
 // do not mess with them, or compilation errors will occur
 //
 
+#if defined(useAtMega328debugMonitor)
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__)
+#undef useSimulatedFIandVSS
+#define useDebugTerminal true
+#define useDebugTerminalHelp true
+#define useDebugTerminalLabels true
+#define useDebugTerminalSWEET64 true
+#define useSWEET64RAMprograms true
+#define useDebugTerminalSerialPort0 true
+#undef useDebugTerminalSerialPort1
+#undef useDebugTerminalSerialPort2
+#undef useDebugTerminalSerialPort3
+#undef useDebugTerminalSerialUSB
+#undef useDebugButtonInjection
+#if defined(__AVR_ATmega328P__)
+//#undef useSWEET64RAMprograms
+#undef useDebugCPUreading
+#undef useAnalogMuxButtons
+#undef useParallax5PositionSwitch
+#undef useAdafruitRGBLCDbuttons
+#undef useGenericTWIbuttons
+#undef useAnalogButtons
+#undef useTWIbuttons
+#undef useButtonInput
+#undef useOutputPins
+#undef useCPUreading
+#undef useSoftwareClock
+#undef useDS1307clock
+#undef useDragRaceFunction
+#undef useDeepSleep
+#undef useCalculatedFuelFactor
+#undef useLegacyBoard
+#undef useJellyBeanDriverBoard
+#undef useArduinoMega2560
+#undef useAdafruitRGBLCDshield
+#undef useTinkerkitLCDmodule
+#undef useMPGuinoColourTouch
+#undef useLegacyButtons
+#undef useWindowTripFilter
+#undef useDFR0009LCD
+#undef useAdafruitRGBLCDdisplay
+#undef useParallaxSerialLCDmodule
+#undef useSainSmart2004LCD
+#undef useGenericTWILCD
+#undef useSerialLCD
+#undef useTWI4BitLCD
+#undef usePort4BitLCD
+#undef use4BitLCD
+#undef useBigFE
+#undef useBigDTE
+#undef useBigTTE
+#undef useBigTimeDisplay
+#undef useBigNumberDisplay
+#undef useBigDigitDisplay
+#undef useBarFuelEconVsTime
+#undef useBarFuelEconVsSpeed
+#undef useBarGraph
+#undef useStatusMeter
+#undef useSpiffyTripLabels
+#undef useSpiffyBigChars
+#undef useLCDfonts
+#undef useLCDgraphics
+#undef useScreenEditor
+#undef blankScreenOnMessage
+#undef useClockDisplay
+#undef useExpandedMainDisplay
+#undef useLCDoutput
+#undef useLCDcontrast
+#undef useBinaryLCDbrightness
+#undef useBluetooth
+#undef useBluetoothAdaFruitSPI
+#undef useDataLoggingOutput
+#undef useJSONoutput
+#undef useLoggingBufferedOutput
+#undef useJSONserialBufferedOutput
+#undef useBluetoothBufferedOutput
+#endif // defined(__AVR_ATmega328P__)
+#if defined(__AVR_ATmega2560__)
+#define useDebugCPUreading true
+#endif // defined(__AVR_ATmega2560__)
+#else // defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__)
+#undef useAtMega328debugMonitor
+#endif // defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__)
+#endif // defined(useAtMega328debugMonitor)
+
 #if ( defined(useLegacyBoard) + defined(useJellyBeanDriverBoard) + defined(useArduinoMega2560) + defined(useTinkerkitLCDmodule) + defined(useMPGuinoColourTouch) ) > 1
 #error *** Pre-defined MPGuino board conflict exists!!! ***
 #endif // ( defined(useLegacyBoard) + defined(useJellyBeanDriverBoard) + defined(useArduinoMega2560) + defined(useTinkerkitLCDmodule) + defined(useMPGuinoColourTouch) ) > 1
@@ -264,6 +350,25 @@
 #undef useParallaxSerialLCDmodule
 #undef useSainSmart2004LCD
 #undef useGenericTWILCD
+#undef useLCDcontrast
+#undef useBinaryLCDbrightness
+#undef useLCDfonts
+#undef useLCDgraphics
+#undef useBigFE
+#undef useBigDTE
+#undef useBigTTE
+#undef useBigTimeDisplay
+#undef useBigNumberDisplay
+#undef useBigDigitDisplay
+#undef useBarFuelEconVsTime
+#undef useBarFuelEconVsSpeed
+#undef useBarGraph
+#undef useStatusMeter
+#undef useSpiffyTripLabels
+#undef useSpiffyBigChars
+#undef useScreenEditor
+#undef blankScreenOnMessage
+#undef useExpandedMainDisplay
 #endif // defined(useTFToutput)
 
 #if defined(useTouchScreenInput)
@@ -543,9 +648,9 @@ static const uint8_t TWIaddressRTC = addressTWIRTC;
 #undef useJSONserialBufferedOutput
 #endif // defined(useJSONoutput)
 
-#if defined(useDebugTerminal) && defined(__AVR_ATmega328P__)
+#if defined(useDebugTerminal) && defined(__AVR_ATmega328P__) && !defined(useAtMega328debugMonitor)
 #undef useDebugTerminal
-#endif // defined(useDebugTerminal) && defined(__AVR_ATmega328P__)
+#endif // defined(useDebugTerminal) && defined(__AVR_ATmega328P__) && !defined(useAtMega328debugMonitor)
 
 #if defined(useDebugTerminal)
 #if ( defined(useDebugTerminalSerialPort0) + defined(useDebugTerminalSerialPort1) + defined(useDebugTerminalSerialPort2) + defined(useDebugTerminalSerialPort3) + defined(useDebugTerminalSerialUSB) ) != 1

--- a/mpguino_tav/feature_debug.h
+++ b/mpguino_tav/feature_debug.h
@@ -34,11 +34,11 @@ namespace systemInfo /* CPU loading and RAM availability support section prototy
 
 };
 
-#if defined(useCPUreading)
+#if defined(useCPUreading) || defined(useDebugCPUreading)
 extern char __bss_end;
 extern char *__brkval;
 
-#endif // defined(useCPUreading)
+#endif // defined(useCPUreading) || defined(useDebugCPUreading)
 #endif // defined(useCPUreading) || defined(useDebugCPUreading)
 #if defined(useSimulatedFIandVSS)
 namespace signalSim /* VSS / fuel injector on-board simulator support section prototype */
@@ -272,6 +272,7 @@ namespace terminal /* debug terminal section prototype */
 	static void outputSWEET64errorLatch(void);
 	static void reportSWEET64error(union union_32 * instrLWord, s64pc_t &prgmPtr, s64pc_t prgmStack[], uint64_t * prgmReg64, uint8_t * prgmReg8);
 	static void dumpSWEET64information(union union_32 * instrLWord, s64pc_t &prgmPtr, s64pc_t prgmStack[], uint64_t * prgmReg64, uint8_t * prgmReg8);
+	static void hexByteOut(uint8_t devIdx, uint8_t val);
 #if defined(useDebugTerminalLabels)
 	static void outputSWEET64functionLength(uint8_t lineNumber);
 #endif // defined(useDebugTerminalLabels)
@@ -295,11 +296,11 @@ namespace terminal /* debug terminal section prototype */
 	static uint8_t pullSWEET64assemblerOperand(uint8_t &byt, uint8_t labelIdx);
 #if defined(useDebugTerminalLabels)
 	static uint8_t findSWEET64labelByte(char * token, uint8_t labelIdx, uint8_t &byt);
-	static void getSWEET64operandLabelIndexes(uint8_t instr, uint8_t format, uint8_t &operandLabelIdx, uint8_t &extraLabelIdx);
 #endif // defined(useDebugTerminalLabels)
 	static uint8_t assembleSWEET64programRAMline(void);
 #endif // defined(useSWEET64RAMprograms)
 #if defined(useDebugTerminalLabels)
+	static void getSWEET64operandLabelIndexes(uint8_t instr, uint8_t format, uint8_t &operandLabelIdx, uint8_t &extraLabelIdx);
 	static void outputSWEET64prgmOperand(s64pc_t prgmPtr, uint8_t flag, uint8_t byt, uint8_t labelIdx);
 #else // defined(useDebugTerminalLabels)
 	static void outputSWEET64prgmOperand(s64pc_t prgmPtr, uint8_t flag, uint8_t byt);
@@ -308,8 +309,7 @@ namespace terminal /* debug terminal section prototype */
 #endif // defined(useDebugTerminalSWEET64)
 	static void processMath(uint8_t cmd);
 	static void outputDecimalSettings(void);
-	static uint8_t outputSystemStatusFlag(uint8_t flags, uint8_t mask, const char * label, uint8_t needsSeparator);
-	static void outputSystemStatusFlagGroup(const char * label, uint8_t flags, uint8_t groupIdx);
+	static void outputFlagStatusGroup(const char * flagGroup, uint8_t flags, uint8_t labelFlag);
 	static void outputSystemStatusFlags(void);
 	static void outputSystemStatusBytes(void);
 #if defined(useBluetoothAdaFruitSPI)
@@ -463,103 +463,102 @@ static const uint8_t tmButtonReadIn =		(tmButtonInput | tmByteReadIn);
 
 #if defined(useDebugTerminalHelp)
 static const char terminalHelp[] PROGMEM = {
-	"       [y].[x]P - list stored parameters, optionally between [y] and [x]" tcEOSCR
+	tcSP7 "[y].[x]P - list stored parameters, optionally between [y] and [x]" tcEOSCR
 	"xP:y [y] [y]... - store one or more y values, starting at stored parameter x" tcCR tcEOSCR
 
-	"       [y].[x]V - list program variables, optionally between [y] and [x]" tcEOSCR
+	tcSP7 "[y].[x]V - list program variables, optionally between [y] and [x]" tcEOSCR
 	"xV:y [y] [y]... - store one or more y values, starting at program variable x" tcCR tcEOSCR
 
-	"       [y].[x]T - list terminal trip variable values, optionally between [y]" tcEOSCR
-	"                  and [x]" tcEOSCR
-	"xT:y [y] [y]... - store one or more y values, starting at terminal trip" tcEOSCR
-	"                  variable x" tcCR tcEOSCR
+	tcSP7 "[y].[x]T - list terminal trip variable values, optionally between [y] and [x]" tcCR tcEOSCR
+	"xT:y [y] [y]... - store one or more y values, starting at terminal trip variable x" tcCR tcEOSCR
 
 #if defined(useDebugTerminalSWEET64)
-	"      [y].[x]^E - list SWEET64 register contents" tcEOSCR
-	"                   [z] - decimal window length (optional)" tcEOSCR
-	"                   [y] - decimal digit count (optional)" tcEOSCR
-	"                   [x] - decimal processing flag (optional)" tcCR tcEOSCR
+	tcSP11 "N - toggle SWEET64 error mute (suppress/unsuppress repeated error output)" tcCR tcEOSCR
+	tcSP6 "[y].[x]^E - list SWEET64 register contents" tcEOSCR
+	tcSP19 "[z] - decimal window length (optional)" tcEOSCR
+	tcSP19 "[y] - decimal digit count (optional)" tcEOSCR
+	tcSP19 "[x] - decimal processing flag (optional)" tcCR tcEOSCR
 	"x^E:y           - store one or more y values, starting at SWEET64 register x" tcCR tcEOSCR
 #if defined(useSWEET64RAMprograms)
-	"       [x]!    - assemble SWEET64 into program RAM, starting at x" tcEOSCR
-	"       [y].[x]M - dump SWEET64 program RAM, optionally between [y] and [x]" tcEOSCR
+	tcSP7 "[x]!    - assemble SWEET64 into program RAM, starting at x" tcEOSCR
+	tcSP7 "[y].[x]M - dump SWEET64 program RAM, optionally between [y] and [x]" tcEOSCR
 	"xM:y [y] [y]... - store one or more bytes, starting at SWEET64 program RAM x" tcEOSCR
-	"       [x]<M    - fill SWEET64 program RAM with x, default 00" tcEOSCR
-	"       x<yM    - copy SWEET64 program y to program RAM, starting at x" tcEOSCR
-	"       x<^L    - list SWEET64 program RAM as pseudo-code, starting at x" tcEOSCR
-	"       x.y^T   - trace SWEET64 function x, optionally for y lines" tcEOSCR
-	"       z<y^T   - trace SWEET64 program RAM at z, optionally for y lines" tcEOSCR
-	"                  if y is omitted, traces 1 line; if y is 0, traces until done" tcCR tcEOSCR
-	"       x.y^W   - export SWEET64 program RAM between x and y as source" tcEOSCR
-	"       x<y^O   - substitute program RAM at x for SWEET64 function y" tcEOSCR
-	"       ^O      - disable SWEET64 program RAM substitution" tcCR tcEOSCR
+	tcSP7 "[x]<M    - fill SWEET64 program RAM with x, default 00" tcEOSCR
+	tcSP7 "x<yM    - copy SWEET64 program y to program RAM, starting at x" tcEOSCR
+	tcSP7 "x<^L    - list SWEET64 program RAM as pseudo-code, starting at x" tcEOSCR
+	tcSP7 "x.y^T   - trace SWEET64 function x, optionally for y lines" tcEOSCR
+	tcSP7 "z<y^T   - trace SWEET64 program RAM at z, optionally for y lines" tcEOSCR
+	tcSP18 "if y is omitted, traces 1 line; if y is 0, traces until done" tcCR tcEOSCR
+	tcSP7 "x.y^W   - export SWEET64 program RAM between x and y as source" tcEOSCR
+	tcSP7 "x<y^O   - substitute program RAM at x for SWEET64 function y" tcEOSCR
+	tcSP7 "^O      - disable SWEET64 program RAM substitution" tcCR tcEOSCR
 #endif // defined(useSWEET64RAMprograms)
 
 #endif // defined(useDebugTerminalSWEET64)
-	"    [y].[x]O - list program constants, optionally between [y] and [x]" tcEOSCR
-	"[z]<[y].[x]L - list terminal trip variable function outputs, optionally" tcEOSCR
-	"               between [y] and [x]" tcEOSCR
-	"                [z] - decimal window length (optional)" tcEOSCR
+	tcSP4 "[y].[x]O - list program constants, optionally between [y] and [x]" tcEOSCR
+	"[z]<[y].[x]L - list terminal trip variable function outputs, optionally between [y] and [x]" tcEOSCR
+	tcSP16 "[z] - decimal window length (optional)" tcCR tcEOSCR
+#if !defined(useAtMega328debugMonitor)
 	"[z]<[y].[x]U - list decimal number sample for output" tcEOSCR
-	"                [z] - decimal window length (optional)" tcEOSCR
-	"                [y] - decimal digit count (optional)" tcEOSCR
-	"                [x] - decimal processing flag (optional)" tcCR tcEOSCR
+	tcSP16 "[z] - decimal window length (optional)" tcEOSCR
+	tcSP16 "[y] - decimal digit count (optional)" tcEOSCR
+	tcSP16 "[x] - decimal processing flag (optional)" tcCR tcEOSCR
+#endif // !defined(useAtMega328debugMonitor)
 
 #if defined(useDebugTerminalSWEET64)
-	"   [y].[x]^I - list SWEET64 instructions, along with their operands, optionally" tcEOSCR
-	"               between [y] and [x]" tcEOSCR
+	tcSP3 "[y].[x]^I - list SWEET64 instructions, along with their operands, optionally between [y] and [x]" tcCR tcEOSCR
 #if defined(useDebugTerminalLabels)
-	"   [y].[x]^F - list all available SWEET64 functions and byte lengths," tcEOSCR
-	"               optionally between [y] and [x]" tcEOSCR
+	tcSP3 "[y].[x]^F - list all available SWEET64 functions and byte lengths, optionally between [y] and [x]" tcCR tcEOSCR
 #endif // defined(useDebugTerminalLabels)
-	"       [x]^L - list 20 lines of SWEET64 program code, optionally beginning at" tcEOSCR
-	"               trip function [x]" tcEOSCR
+	tcSP7 "[x]^L - list 20 lines of SWEET64 program code, optionally beginning at trip function [x]" tcCR tcEOSCR
 #if !defined(useSWEET64RAMprograms)
-	"       x.y^T - trace SWEET64 function x, optionally for y lines" tcEOSCR
-	"               if y is omitted, traces 1 line" tcEOSCR
-	"               if y is explicitly set to 0, traces until program completes" tcCR tcEOSCR
+	tcSP7 "x.y^T - trace SWEET64 function x, optionally for y lines" tcEOSCR
+	tcSP15 "if y is omitted, traces 1 line" tcEOSCR
+	tcSP15 "if y is explicitly set to 0, traces until program completes" tcCR tcEOSCR
 #endif // !defined(useSWEET64RAMprograms)
 
 #endif // defined(useDebugTerminalSWEET64)
-	"    [y]<[x]R - read trip variable x into trip variable y" tcEOSCR
-	"                default for x and y is terminal trip variable" tcEOSCR
+	tcSP4 "[y]<[x]R - read trip variable x into trip variable y" tcEOSCR
+	tcSP16 "default for x and y is terminal trip variable" tcEOSCR
 #if defined(useDebugTerminalLabels)
-	"                if no x or y specified, lists available trip variables" tcCR tcEOSCR
+	tcSP16 "if no x or y specified, lists available trip variables" tcCR tcEOSCR
 #else // defined(useDebugTerminalLabels)
-	"                either or both of x or y must be specified" tcCR tcEOSCR
+	tcSP16 "either or both of x or y must be specified" tcCR tcEOSCR
 #endif // defined(useDebugTerminalLabels)
 
-	"   [z]<[y].x - enters a number x into the 64-bit math accumulator" tcEOSCR
-	"                [z] - decimal window length (optional)" tcEOSCR
-	"                [y] - decimal digit count (optional)" tcEOSCR
-	"          +x - adds x to math accumulator" tcEOSCR
-	"          -x - subtracts x from math accumulator" tcEOSCR
-	"          *x - multiplies math accumulator by x" tcEOSCR
+#if !defined(useAtMega328debugMonitor)
+	tcSP3 "[z]<[y].x - enters a number x into the 64-bit math accumulator" tcEOSCR
+	tcSP16 "[z] - decimal window length (optional)" tcEOSCR
+	tcSP16 "[y] - decimal digit count (optional)" tcEOSCR
+	tcSP10 "+x - adds x to math accumulator" tcEOSCR
+	tcSP10 "-x - subtracts x from math accumulator" tcEOSCR
+	tcSP10 "*x - multiplies math accumulator by x" tcEOSCR
 #if defined(useIsqrt)
-	"          |  - finds square root of math accumulator" tcEOSCR
+	tcSP10 "|  - finds square root of math accumulator" tcEOSCR
 #endif // defined(useIsqrt)
-	"          /x - divides math accumulator by x" tcEOSCR
-	"          =x - enters a number x into the 64-bit math accumulator" tcCR tcEOSCR
+	tcSP10 "/x - divides math accumulator by x" tcEOSCR
+	tcSP10 "=x - enters a number x into the 64-bit math accumulator" tcCR tcEOSCR
+#endif // !defined(useAtMega328debugMonitor)
 
 #if defined(useDebugButtonInjection)
-	"           I - inject button press" tcEOSCR
+	tcSP11 "I - inject button press" tcEOSCR
 #if defined(useLegacyButtons)
-	"                short (l, c, r)" tcEOSCR
-	"                 long (L, C, R)" tcCR tcEOSCR
+	tcSP16 "short (l, c, r)" tcEOSCR
+	tcSP17 "long (L, C, R)" tcCR tcEOSCR
 #else // defined(useLegacyButtons)
-	"                short (l, c, r, u, d)" tcEOSCR
-	"                 long (L, C, R, U, D)" tcCR tcEOSCR
+	tcSP16 "short (l, c, r, u, d)" tcEOSCR
+	tcSP17 "long (L, C, R, U, D)" tcCR tcEOSCR
 #endif // defined(useLegacyButtons)
 #endif // defined(useDebugButtonInjection)
 #if defined(useSimulatedFIandVSS)
-	"           S - lists available signal simulator modes" tcEOSCR
-	"          yS - sets signal simulator mode to y" tcEOSCR
+	tcSP11 "S - lists available signal simulator modes" tcEOSCR
+	tcSP10 "yS - sets signal simulator mode to y" tcEOSCR
 #endif // defined(useSimulatedFIandVSS)
 #if defined(useBluetoothAdaFruitSPI)
-	"           Y - sends the rest of the input string to BLEfriend shield" tcEOSCR
+	tcSP11 "Y - sends the rest of the input string to BLEfriend shield" tcEOSCR
 #endif // defined(useBluetoothAdaFruitSPI)
-	"          ^S - displays supplemental system information" tcEOSCR
-	"           ? - displays this help" tcEOSCR
+	tcSP10 "^S - displays supplemental system information" tcEOSCR
+	tcSP11 "? - displays this help" tcEOSCR
 	tcEOS
 };
 
@@ -569,11 +568,12 @@ static s64pc_t terminalListSched;
 static s64pc_t terminalExecSched;
 static s64pc_t terminalS64lastErrorPC;
 
-static s64pc_t terminalStack[16];
+static s64pc_t terminalStack[(uint16_t)(s64stackSize)];
 
 static uint8_t terminalS64reg8[(uint16_t)(si64reg8count)];
 static uint8_t terminalS64lastErrorCode;
 static uint8_t terminalS64errorLatched;
+static uint8_t terminalS64errorMuted;
 static uint16_t terminalS64lastErrorCount;
 
 static uint64_t terminalS64reg64[(uint16_t)(s64reg64count)];

--- a/mpguino_tav/feature_debug.ino
+++ b/mpguino_tav/feature_debug.ino
@@ -120,6 +120,7 @@ static const uint8_t prgmFindCPUutilPercent[] PROGMEM = {
 	instrDone											// exit to caller
 };
 
+#endif // defined(useCPUreading) && defined(useButtonInput)
 static const uint8_t prgmOutputOperatingTime[] PROGMEM = {
 	instrLdRegVariable, 0x02, v32SystemCycleIdx,
 	instrDiv2byRdOnly, idxTicks0PerSecond,
@@ -134,6 +135,7 @@ static const uint8_t prgmOutputAvailableRAM[] PROGMEM = {
 	instrDone											// exit to caller
 };
 
+#if defined(useCPUreading) && defined(useButtonInput)
 static uint8_t systemInfo::displayHandler(uint8_t cmd, uint8_t cursorPos)
 {
 
@@ -782,91 +784,29 @@ static void terminal::outputDecimalSettings(void)
 
 }
 
-static uint8_t terminal::outputSystemStatusFlag(uint8_t flags, uint8_t mask, const char * label, uint8_t needsSeparator)
-{
-
-	if ((flags & mask) == 0) return needsSeparator;
-
-	if (needsSeparator) text::charOut(m8DevDebugTerminalIdx, ',');
-	text::stringOut(m8DevDebugTerminalIdx, label);
-	return 1;
-
-}
-
-static void terminal::outputSystemStatusFlagGroup(const char * label, uint8_t flags, uint8_t groupIdx)
+static void terminal::outputFlagStatusGroup(const char * flagGroup, uint8_t flags, uint8_t labelFlag)
 {
 
 	uint8_t foundFlag = 0;
 
-	text::stringOut(m8DevDebugTerminalIdx, label);
+	if (labelFlag) text::stringOut(m8DevDebugTerminalIdx, flagGroup);
 	text::charOut(m8DevDebugTerminalIdx, '=');
 
-	switch (groupIdx)
+	for (uint8_t x = 0; x < 8; x++)
 	{
 
-		case 0:
-			foundFlag = outputSystemStatusFlag(flags, aAwakeOnInjector, PSTR("inj"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, aAwakeOnVSS, PSTR("vss"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, aAwakeOnInput, PSTR("input"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, aAwakeEngineRunning, PSTR("eng"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, aAwakeVehicleMoving, PSTR("move"), foundFlag);
-			break;
+		if (flags & 0x80)
+		{
 
-		case 1:
-			foundFlag = outputSystemStatusFlag(flags, afEngineOffFlag, PSTR("engOff"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, afVehicleStoppedFlag, PSTR("stopped"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, afUserInputFlag, PSTR("input"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, afParkFlag, PSTR("park"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, afActivityTimeoutFlag, PSTR("timeout"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, afVehicleIdleFlag, PSTR("idle"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, afVehicleEOCflag, PSTR("eoc"), foundFlag);
-			break;
+			if (foundFlag) text::charOut(m8DevDebugTerminalIdx, ',');
+			text::stringOut(m8DevDebugTerminalIdx, flagGroup, x + 1);
 
-		case 2:
-			foundFlag = outputSystemStatusFlag(flags, t0cResetTimer, PSTR("reset"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0cResetInputActivityTimer, PSTR("input"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0cResetOutputTimer, PSTR("display"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0cReadRTC, PSTR("rtc"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0cEnableJSONoutput, PSTR("json"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0cEnableOutputPin, PSTR("outPin"), foundFlag);
-			break;
+			foundFlag++;
 
-		case 3:
-			foundFlag = outputSystemStatusFlag(flags, t0saTakeSample, PSTR("sample"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0saUpdateDisplay, PSTR("display"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0saShowCursor, PSTR("cursor"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0saDisplayDelayInit, PSTR("delayInit"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0saDisplayDelayActive, PSTR("delay"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0saOutputJSON, PSTR("json"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0saOutputPinEnabled, PSTR("outPin"), foundFlag);
-			break;
+		}
 
-		case 4:
-			foundFlag = outputSystemStatusFlag(flags, t0sbSampleBLEfriend, PSTR("ble"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0sbReadRTC, PSTR("rtc"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0sbErrorRTC, PSTR("rtcErr"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0sbResetFEvsTimeTrip, PSTR("fevt"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0sbAccelTestFlag, PSTR("accel"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, t0sbCoastdownTestFlag, PSTR("coast"), foundFlag);
-			break;
-
-		case 5:
-			foundFlag = outputSystemStatusFlag(flags, dGoodInjectorOpen, PSTR("open"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, dGoodInjectorClose, PSTR("close"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, dGoodInjectorOpenPeriod, PSTR("period"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, dGoodInjectorRead, PSTR("read"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, dInjectorReadInProgress, PSTR("busy"), foundFlag);
-			break;
-
-		case 6:
-			foundFlag = outputSystemStatusFlag(flags, dGoodVSSsignal, PSTR("signal"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, dVSSreadInProgress, PSTR("busy"), foundFlag);
-			foundFlag = outputSystemStatusFlag(flags, dGoodVSSpulse, PSTR("pulse"), foundFlag);
-			break;
-
-		default:
-			break;
-
+		flags <<= 1;
+		
 	}
 
 	if (foundFlag == 0) text::stringOut(m8DevDebugTerminalIdx, PSTR("none"));
@@ -876,23 +816,20 @@ static void terminal::outputSystemStatusFlagGroup(const char * label, uint8_t fl
 static void terminal::outputSystemStatusFlags(void)
 {
 
-	outputSystemStatusFlagGroup(PSTR("AW"), v08(v8AwakeIdx), 0);
+	outputFlagStatusGroup(awakeFlagMarkers, v08(v8AwakeIdx), 1);
 	text::stringOut(m8DevDebugTerminalIdx, PSTR(" ACT"));
-	outputSystemStatusFlagGroup(PSTR(""), v08(v8ActivityIdx), 1);
+	outputFlagStatusGroup(activityFlagMarkers, v08(v8ActivityIdx), 0);
 	text::stringOut(m8DevDebugTerminalIdx, PSTR(" CHG"));
-	outputSystemStatusFlagGroup(PSTR(""), v08(v8ActivityChangeIdx), 1);
+	outputFlagStatusGroup(activityFlagMarkers, v08(v8ActivityChangeIdx), 0);
 	text::newLine(m8DevDebugTerminalIdx);
 
-	outputSystemStatusFlagGroup(PSTR("T0C"), v08(v8Timer0CommandIdx), 2);
-	text::stringOut(m8DevDebugTerminalIdx, PSTR(" T0S0"));
-	outputSystemStatusFlagGroup(PSTR(""), v08(v8Timer0Status0Idx), 3);
-	text::stringOut(m8DevDebugTerminalIdx, PSTR(" T0S1"));
-	outputSystemStatusFlagGroup(PSTR(""), v08(v8Timer0Status1Idx), 4);
+	outputFlagStatusGroup(timer0CommandFlagMarkers, v08(v8Timer0CommandIdx), 1);
+	outputFlagStatusGroup(timer0Status0FlagMarkers, v08(v8Timer0Status0Idx), 1);
+	outputFlagStatusGroup(timer0Status1FlagMarkers, v08(v8Timer0Status1Idx), 1);
 	text::newLine(m8DevDebugTerminalIdx);
 
-	outputSystemStatusFlagGroup(PSTR("INJ"), v08(v8DirtyInjectorIdx), 5);
-	text::stringOut(m8DevDebugTerminalIdx, PSTR(" VSS"));
-	outputSystemStatusFlagGroup(PSTR(""), v08(v8DirtyVSSIdx), 6);
+	outputFlagStatusGroup(dirtyInjectorFlagMarkers, v08(v8DirtyInjectorIdx), 1);
+	outputFlagStatusGroup(dirtyVSSflagMarkers, v08(v8DirtyVSSIdx), 1);
 	text::newLine(m8DevDebugTerminalIdx);
 
 }
@@ -990,6 +927,7 @@ static void terminal::outputSWEET64errorLatch(void)
 {
 
 	text::stringOut(m8DevDebugTerminalIdx, PSTR("S64 ERR "));
+	if (terminalS64errorMuted) text::stringOut(m8DevDebugTerminalIdx, PSTR("[muted] "));
 
 	if (terminalS64errorLatched)
 	{
@@ -1022,14 +960,18 @@ static void terminal::reportSWEET64error(union union_32 * instrLWord, s64pc_t &p
 	{
 
 		if (terminalS64lastErrorCount < 0xFFFF) terminalS64lastErrorCount++;
-		return;
 
+	}
+	else
+	{
+		terminalS64lastErrorCode = errorCode;
+		terminalS64lastErrorCount = 1;
+		terminalS64lastErrorPC = prgmPtr;
 	}
 
 	terminalS64errorLatched = 1;
-	terminalS64lastErrorCode = errorCode;
-	terminalS64lastErrorCount = 1;
-	terminalS64lastErrorPC = prgmPtr;
+
+	if (terminalS64errorMuted) return;
 
 	outputSWEET64error(errorCode);
 	dumpSWEET64information(instrLWord, prgmPtr, prgmStack, prgmReg64, prgmReg8);
@@ -1042,35 +984,22 @@ static void terminal::dumpSWEET64information(union union_32 * instrLWord, s64pc_
 	outputSWEET64programCounter(prgmPtr);
 	text::charOut(m8DevDebugTerminalIdx, ' ');
 	text::hexDWordOut(m8DevDebugTerminalIdx, instrLWord->u32);
-	text::charOut(m8DevDebugTerminalIdx, ' ');
-	text::hexByteOut(m8DevDebugTerminalIdx, SWEET64processorFlags);
+	outputFlagStatusGroup(SWEET64processorFlagMarkers, SWEET64processorFlags, 1);
 	text::newLine(m8DevDebugTerminalIdx);
 
-	for (uint8_t x = 0; x < 16; x++)
+	for (uint8_t x = 0; x < s64stackSize; x++)
 	{
 
-		text::charOut(m8DevDebugTerminalIdx, 9);
-		text::hexByteOut(m8DevDebugTerminalIdx, x);
-		text::charOut(m8DevDebugTerminalIdx, ' ');
-		outputSWEET64programCounter(prgmStack[(uint16_t)(x)]);
+		hexByteOut(m8DevDebugTerminalIdx, x);
 
-		if (x < s64reg64count)
+		if ((x < prgmReg8[(uint16_t)(si64reg8spnt)]) && (prgmReg8[(uint16_t)(si64reg8spnt)] < s64stackSize))
 		{
 
-			text::charOut(m8DevDebugTerminalIdx, 9, 2);
-			text::hexByteOut(m8DevDebugTerminalIdx, (x + 1));
-			text::charOut(m8DevDebugTerminalIdx, ' ');
-			text::hexLWordOut(m8DevDebugTerminalIdx, &prgmReg64[(uint16_t)(x)]);
-
-		}
-
-		if (x < si64reg8count)
-		{
-
-			text::charOut(m8DevDebugTerminalIdx, 9);
-			text::hexByteOut(m8DevDebugTerminalIdx, x);
-			text::charOut(m8DevDebugTerminalIdx, ' ');
-			text::hexByteOut(m8DevDebugTerminalIdx, prgmReg8[(uint16_t)(x)]);
+			outputSWEET64programCounter(prgmStack[(uint16_t)(x)]);
+			hexByteOut(m8DevDebugTerminalIdx, s64callIndexStack[(uint16_t)(x)]);
+#if defined(useDebugTerminalLabels)
+			text::stringOut(m8DevDebugTerminalIdx, terminalTripFuncNames, s64callIndexStack[(uint16_t)(x)]);
+#endif // defined(useDebugTerminalLabels)
 
 		}
 
@@ -1079,6 +1008,49 @@ static void terminal::dumpSWEET64information(union union_32 * instrLWord, s64pc_
 	}
 
 	text::newLine(m8DevDebugTerminalIdx);
+
+	for (uint8_t x = 0; x < s64reg64count; x++)
+	{
+
+		hexByteOut(m8DevDebugTerminalIdx, x);
+		text::hexLWordOut(m8DevDebugTerminalIdx, &prgmReg64[(uint16_t)(x)]);
+
+#if defined(useDebugTerminalLabels)
+		text::charOut(m8DevDebugTerminalIdx, ' ');
+		text::stringOut(m8DevDebugTerminalIdx, terminalSWEET64registerLabels, x);
+
+#endif // defined(useDebugTerminalLabels)
+		text::newLine(m8DevDebugTerminalIdx);
+
+	}
+
+	text::newLine(m8DevDebugTerminalIdx);
+
+	for (uint8_t x = 0; x < si64reg8count; x++)
+	{
+
+		hexByteOut(m8DevDebugTerminalIdx, x);
+		text::hexByteOut(m8DevDebugTerminalIdx, prgmReg8[(uint16_t)(x)]);
+
+#if defined(useDebugTerminalLabels)
+		text::charOut(m8DevDebugTerminalIdx, ' ');
+		text::stringOut(m8DevDebugTerminalIdx, terminalSWEET64registerLabels, x + s64reg64count);
+
+#endif // defined(useDebugTerminalLabels)
+		text::newLine(m8DevDebugTerminalIdx);
+
+	}
+
+	text::newLine(m8DevDebugTerminalIdx);
+
+}
+
+static void terminal::hexByteOut(uint8_t devIdx, uint8_t val)
+{
+
+	text::charOut(devIdx, 9);
+	text::hexByteOut(devIdx, val);
+	text::charOut(devIdx, ' ');
 
 }
 
@@ -1569,82 +1541,6 @@ static uint8_t terminal::findSWEET64labelByte(char * token, uint8_t labelIdx, ui
 
 }
 
-static void terminal::getSWEET64operandLabelIndexes(uint8_t instr, uint8_t format, uint8_t &operandLabelIdx, uint8_t &extraLabelIdx)
-{
-
-	operandLabelIdx = 0;
-	extraLabelIdx = 0;
-
-	if ((format & rxxMask) != r00) // instruction does something with the 64 bit registers
-	{
-
-		switch (instr & ixxMask) // perform load or store operation, according to ixx
-		{
-
-			case i14:	// load rX with const
-				operandLabelIdx = dslIdxConst;
-				break;
-
-			case i03:	// load rX with EEPROM
-			case i04:	// store EEPROM rX
-				operandLabelIdx = dslIdxEEPROM;
-				break;
-
-			case i07:	// load rX with volatile
-			case i08:	// store volatile rX
-				operandLabelIdx = dslIdxProgramVariable;
-				break;
-
-#if defined(useBarFuelEconVsTime)
-			case i17:	// load rX with FEvT trip variable
-#endif // defined(useBarFuelEconVsTime)
-			case i18:	// load rX with trip variable
-			case i19:	// store trip variable rX
-				operandLabelIdx = dslIdxTripVariable;
-				extraLabelIdx = dslIdxTripMeasurement;
-				break;
-
-			case i31:	// BCD adjust
-				operandLabelIdx = dslIdxBCDformat;
-				break;
-
-			default:
-				break;
-
-		}
-
-	}
-	else
-	{
-
-		if (instr >= eMaxBranchInstrIdx)
-		{
-
-			switch (instr)
-			{
-
-				case e29:	// load jump register
-				case e27:	// call
-				case e28:	// jump
-					extraLabelIdx = dslIdxFunction;
-					break;
-
-				case e24:	// load index EEPROM
-				case e26:	// load index EEPROM parameter length
-					extraLabelIdx = dslIdxEEPROM;
-					break;
-
-				default:
-					break;
-
-			}
-
-		}
-
-	}
-
-}
-
 #endif // defined(useDebugTerminalLabels)
 
 static uint8_t terminal::pullSWEET64assemblerOperand(uint8_t &byt, uint8_t labelIdx)
@@ -1766,6 +1662,84 @@ static uint8_t terminal::assembleSWEET64programRAMline(void)
 }
 
 #endif // defined(useSWEET64RAMprograms)
+#if defined(useDebugTerminalLabels)
+static void terminal::getSWEET64operandLabelIndexes(uint8_t instr, uint8_t format, uint8_t &operandLabelIdx, uint8_t &extraLabelIdx)
+{
+
+	operandLabelIdx = 0;
+	extraLabelIdx = 0;
+
+	if ((format & rxxMask) != r00) // instruction does something with the 64 bit registers
+	{
+
+		switch (instr & ixxMask) // perform load or store operation, according to ixx
+		{
+
+			case i14:	// load rX with const
+				operandLabelIdx = dslIdxConst;
+				break;
+
+			case i03:	// load rX with EEPROM
+			case i04:	// store EEPROM rX
+				operandLabelIdx = dslIdxEEPROM;
+				break;
+
+			case i07:	// load rX with volatile
+			case i08:	// store volatile rX
+				operandLabelIdx = dslIdxProgramVariable;
+				break;
+
+#if defined(useBarFuelEconVsTime)
+			case i17:	// load rX with FEvT trip variable
+#endif // defined(useBarFuelEconVsTime)
+			case i18:	// load rX with trip variable
+			case i19:	// store trip variable rX
+				operandLabelIdx = dslIdxTripVariable;
+				extraLabelIdx = dslIdxTripMeasurement;
+				break;
+
+			case i31:	// BCD adjust
+				operandLabelIdx = dslIdxBCDformat;
+				break;
+
+			default:
+				break;
+
+		}
+
+	}
+	else
+	{
+
+		if (instr >= eMaxBranchInstrIdx)
+		{
+
+			switch (instr)
+			{
+
+				case e29:	// load jump register
+				case e27:	// call
+				case e28:	// jump
+					extraLabelIdx = dslIdxFunction;
+					break;
+
+				case e24:	// load index EEPROM
+				case e26:	// load index EEPROM parameter length
+					extraLabelIdx = dslIdxEEPROM;
+					break;
+
+				default:
+					break;
+
+			}
+
+		}
+
+	}
+
+}
+
+#endif // defined(useDebugTerminalLabels)
 static void terminal::outputSWEET64operand(uint8_t flag, uint8_t &byt)
 {
 
@@ -2759,9 +2733,11 @@ x^E:y           - store one or more y values, starting at SWEET64 register x
 
 #endif // defined(useDebugButtonInjection)
 								case 0x13:	// display supplemental system information
+#if defined(useCPUreading) || defined(useDebugCPUreading)
 									text::stringOut(m8DevDebugTerminalIdx, PSTR("UP "));
 									text::stringOut(m8DevDebugTerminalIdx, ull2str(nBuff, 0, S64_PRGM_PTR(prgmOutputOperatingTime)));
 									text::newLine(m8DevDebugTerminalIdx);
+#endif // defined(useCPUreading) || defined(useDebugCPUreading)
 #if defined(useClockDisplay)
 									text::stringOut(m8DevDebugTerminalIdx, PSTR("CLK "));
 									text::stringOut(m8DevDebugTerminalIdx, ull2str(nBuff, 0, S64_PRGM_PTR(prgmOutputClockTime)));
@@ -2868,6 +2844,13 @@ x^E:y           - store one or more y values, starting at SWEET64 register x
 									terminalMode |= (tmInitInput); // shift to reading a new numeric value
 									break;
 
+#if defined(useDebugTerminalSWEET64)
+								case 'N':	// toggle SWEET64 error output mute
+									terminalS64errorMuted ^= 1;
+									terminalState = tsInitProcessing;
+									break;
+
+#endif // defined(useDebugTerminalSWEET64)
 								case 'L':   // list available trip functions
 									if (terminalMode & tmTargetReadIn) decWindow = terminalTarget; // if decimal window specified, save it
 
@@ -3369,8 +3352,7 @@ x^E:y           - store one or more y values, starting at SWEET64 register x
 						terminalExecSched = SWEET64::makeProgmemProgram(0);
 
 					}
-
-					if (terminalS64reg8[(uint16_t)(si64reg8flags)] & SWEET64traceFlag) // if trace flag is still enabled, output register values
+					else if (terminalS64reg8[(uint16_t)(si64reg8flags)] & SWEET64traceFlag) // if trace flag is still enabled, output register values
 						dumpSWEET64information(iLW, terminalExecSched, terminalStack, terminalS64reg64, terminalS64reg8);
 
 				}

--- a/mpguino_tav/feature_outputpin.ino
+++ b/mpguino_tav/feature_outputpin.ino
@@ -10,17 +10,22 @@
 	4	instant fuel economy > tank fuel economy (0 - false, 255 - true)
 	5	estimated tank fuel consumed (0 (none) to 255 (all of the tank), based on tank size)
 	6	estimated tank fuel remaining (0 (empty) to 255 (full), based on tank size)
+	7	instant fuel economy analog, 0 to pOutputPinMaxFuelEconomy (0 (zero FE) to 255 (at or above max FE))
+	8	instant fuel economy analog, 0 to 1.5 * current trip average FE (0 (zero) to 255 (at 1.5x average))
+	9	instant fuel economy analog, 0 to 1.5 * tank trip average FE (0 (zero) to 255 (at 1.5x average))
 */
 static const uint8_t prgmCalculateOutputPinValue[] PROGMEM = {
 	instrCmpIndex, 2,									// is a valid expansion output pin number being requested?
-	instrBranchIfGTorE, 13,								// skip to output a zero if not
+	instrBranchIfGTorE, 17,								// skip to output a zero if not
 	instrLxdIEEPROMoffset, pOutputPin1Mode,				// load the indexed stored parameter index for the expansion output pin setting
 	instrTestIndex,										// test pin mode value for zero
-	instrBranchIfZero, 8,								// exit out if pin mode is zero
+	instrBranchIfZero, 12,								// exit out if pin mode is zero
 	instrCmpIndex, 4,									// test if pin mode is "fuel economy comparison between instant and whatever"
-	instrBranchIfLTorE,	26,								// if so, skip ahead
+	instrBranchIfLTorE, 30,								// if so, skip ahead
 	instrCmpIndex, 6,									// test if pin mode is analog output tank quantity or quantity remaining
-	instrBranchIfLTorE, 4,								// if so, skip ahead
+	instrBranchIfLTorE, 8,								// if so, skip ahead
+	instrCmpIndex, 9,									// test if pin mode is analog FE output
+	instrBranchIfLTorE, 78,								// if so, skip ahead
 
 //zeroOutRet:
 	instrLdRegByte, 0x02, 0,							// zero out result
@@ -81,11 +86,85 @@ static const uint8_t prgmCalculateOutputPinValue[] PROGMEM = {
 	instrDone,											// return to caller
 
 	instrLdRegByte, 0x02, 0,							// zero out result
+	instrDone,											// exit to caller
+
+// for analog FE output (modes 7-9) the gauge always uses distance/fuel ratio regardless of metric mode setting,
+// so that higher output always means better fuel economy in all unit configurations
+
+//feAnalog:
+// mode 7: instant FE analog output scaled to pOutputPinMaxFuelEconomy
+// PWM = (inst_VSS * m32CyclesPerVolume * idxDecimalPoint * 255) / (inst_InjCycles * pPulseEdgePerDistance * pOutputPinMaxFuelEconomy)
+// pOutputPinMaxFuelEconomy is stored as FE * idxDecimalPoint (e.g. 50000 = 50 MPG or 50 KPL after metric conversion)
+	instrCmpIndex, 7,									// test if mode 7 (absolute max FE)
+	instrBranchIfGT, 41,								// if mode > 7, skip to modes 8/9 handler
+	instrLdRegTripVar, 0x02, instantIdx, rvInjCycleIdx,	// fetch instant injector open cycles (fuel denominator)
+	instrTestReg, 0x02,									// test for zero (coasting / engine off)
+	instrBranchIfNotZero, 4,							// if non-zero, skip to computation
+	instrLdRegByte, 0x02, 0,							// zero output when coasting
+	instrDone,											// exit to caller
+	instrMul2byEEPROM, pPulseEdgePerDistanceIdx,		// multiply by pulse edges per distance
+	instrMul2byEEPROM, pOutputPinMaxFuelEconomy,		// multiply by stored max FE (FE * idxDecimalPoint)
+	instrLdReg, 0x21,									// save denominator in register 1
+	instrLdRegTripVar, 0x02, instantIdx, rvVSSpulseIdx,	// fetch instant VSS pulses (distance numerator)
+	instrMul2byVariable, m32CyclesPerVolumeIdx,			// multiply by cycles per unit volume
+	instrMul2byRdOnly, idxDecimalPoint,					// scale by idxDecimalPoint (cancels stored max FE scaling)
+	instrMul2byByte, 255,								// scale to 0-255 output range
+	instrDiv2by1,										// compute PWM = numerator / denominator
+	instrAdjustQuotient,								// round result
+	instrLdRegByte, 0x01, 255,							// load 255 for clamp comparison
+	instrCmpXtoY, 0x21,									// compare result to 255
+	instrBranchIfLTorE, 3,								// if result <= 255, skip clamp
+	instrLdRegByte, 0x02, 255,							// clamp output to 255
+	instrDone,											// exit to caller
+
+// modes 8/9: instant FE analog output scaled to 1.5 * average FE (current trip or tank)
+// PWM = (inst_VSS * accum_InjCycles * 170) / (inst_InjCycles * accum_VSS)
+// where 170 = 255 / 1.5, so full scale (255) corresponds to 1.5 * average FE
+// this computation is unit-agnostic: distance and fuel conversion factors cancel in the ratio
+	instrCmpIndex, 9,									// test if mode 9 (tank average)
+	instrBranchIfLT, 10,								// if mode < 9 (i.e. mode 8), skip to current trip load
+	instrLdRegTripVar, 0x03, tankIdx, rvInjCycleIdx,	// fetch tank accumulated injector open cycles
+	instrLdRegTripVar, 0x02, tankIdx, rvVSSpulseIdx,	// fetch tank accumulated VSS pulses
+	instrSkip, 8,										// skip current trip load
+	instrLdRegTripVar, 0x03, currentIdx, rvInjCycleIdx,	// fetch current accumulated injector open cycles
+	instrLdRegTripVar, 0x02, currentIdx, rvVSSpulseIdx,	// fetch current accumulated VSS pulses
+	instrTestReg, 0x02,									// test accum_VSS for zero (no trip data yet)
+	instrBranchIfNotZero, 4,							// if non-zero, continue
+	instrLdRegByte, 0x02, 0,							// zero output when no trip data
+	instrDone,											// exit to caller
+	instrLdRegTripVar, 0x01, instantIdx, rvInjCycleIdx,	// fetch instant injector open cycles
+	instrTestReg, 0x01,									// test for zero (coasting / engine off)
+	instrBranchIfNotZero, 4,							// if non-zero, continue
+	instrLdRegByte, 0x02, 0,							// zero output when coasting
+	instrDone,											// exit to caller
+	instrMul2by1,										// reg2 = accum_VSS * inst_InjCycles (denominator)
+	instrLdReg, 0x21,									// save denominator in register 1
+	instrSwapReg, 0x13,									// swap: reg1 = accum_InjCycles, reg3 = denominator
+	instrLdRegTripVar, 0x02, instantIdx, rvVSSpulseIdx,	// fetch instant VSS pulses
+	instrMul2by1,										// reg2 = inst_VSS * accum_InjCycles (numerator part)
+	instrMul2byByte, 170,								// scale to 0-255 range at 1.5x average (255/1.5 = 170)
+	instrSwapReg, 0x13,									// swap back: reg1 = denominator, reg3 = accum_InjCycles
+	instrDiv2by1,										// compute PWM = numerator / denominator
+	instrAdjustQuotient,								// round result
+	instrLdRegByte, 0x01, 255,							// load 255 for clamp comparison
+	instrCmpXtoY, 0x21,									// compare result to 255
+	instrBranchIfLTorE, 3,								// if result <= 255, skip clamp
+	instrLdRegByte, 0x02, 255,							// clamp output to 255
 	instrDone											// exit to caller
 };
 
 static void outputPin::init(void)
 {
+
+// PWM frequencies for RC DAC filter design (PWM -> RC low-pass -> 0-5V analog output):
+//
+// ATmega32U4  Timer4  EXP1 (OC4A) + EXP2 (OC4D): high-speed timer with PLL; WGM/CS set by Arduino core (board-specific)
+// ATmega2560  Timer5  EXP1 (OC5A) + EXP2 (OC5B): Arduino core sets phase-correct 8-bit PWM, prescaler 64
+//                     f_PWM = 16 MHz / (2 * 64 * 255) = 490 Hz
+// ATmega328P  Timer1  EXP1 (OC1B): heart.ino sets phase-correct 8-bit PWM, prescaler 1
+//                     f_PWM = 16 MHz / (2 * 1 * 255) = 31,373 Hz
+// ATmega328P  Timer2  EXP2 (OC2A): overridden below to phase-correct 8-bit PWM, prescaler 1
+//                     f_PWM = 16 MHz / (2 * 1 * 255) = 31,373 Hz  (matches EXP1)
 
 #if defined(__AVR_ATmega32U4__)
 	// set OC4A to clear-up/set-down PWM mode for EXP1 option pin
@@ -122,6 +201,12 @@ static void outputPin::init(void)
 	// set OC2A to clear-up/set-down for EXP2 option pin
 	TCCR2A &= ~(1 << COM2A0);
 	TCCR2A |= (1 << COM2A1);
+
+	// set Timer2 to phase-correct 8-bit PWM, prescaler 1 (matches Timer1/EXP1 at 31,373 Hz)
+	TCCR2A &= ~_BV(WGM21);
+	TCCR2A |= _BV(WGM20);
+	TCCR2B &= ~(_BV(CS22) | _BV(CS21));
+	TCCR2B |= _BV(CS20);
 
 	// enable EXP1 and EXP2 option pin outputs
 	DDRB |= ((1 << DDB3) | (1 << DDB2));

--- a/mpguino_tav/feature_settings.h
+++ b/mpguino_tav/feature_settings.h
@@ -34,7 +34,7 @@ static const uint8_t displayCountSettingsDisplay = 2
 	+ 1
 #endif // defined(useFuelCost)
 #if defined(useOutputPins)
-	+ 2
+	+ 3
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 	+ 1
@@ -141,6 +141,7 @@ static const char settingsSubMenuTitles[] PROGMEM = {	// each title must be no l
 #if defined(useOutputPins)
 	"OutPtPin 1 Mode" tcEOSCR
 	"OutPtPin 2 Mode" tcEOSCR
+	"OutPtPin MaxFE" tcEOSCR
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 	"V(diode)*1000" tcEOSCR
@@ -272,6 +273,7 @@ static const char settingsParameterList[] PROGMEM = {
 #if defined(useOutputPins)
 	pOutputPin1Mode,
 	pOutputPin2Mode,
+	pOutputPinMaxFuelEconomy,
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 	pVoltageOffset,

--- a/mpguino_tav/heart.h
+++ b/mpguino_tav/heart.h
@@ -455,12 +455,6 @@ static const uint8_t v8RTCyearIdx =						v8RTCmonthIdx + 1;
 static const uint8_t v8RTCcontrolIdx =					v8RTCyearIdx + 1;
 #define nextAllowedValue v8RTCcontrolIdx + 1
 #endif // defined(useDS1307clock)
-#if defined(useOutputPins)
-static const uint8_t v8OutputPinCurrentIdx =			nextAllowedValue;
-static const uint8_t v8OutputPinBitmask =				v8OutputPinCurrentIdx + 1;
-static const uint8_t v8OutputPinOCvalue =				v8OutputPinBitmask + 16;
-#define nextAllowedValue v8OutputPinOCvalue + 16
-#endif // defined(useOutputPins)
 
 static const uint8_t v8VariableEndIdx =					nextAllowedValue;						// end of 8-bit volatile variable storage
 static const uint8_t v8VariableLength =					v8VariableEndIdx - v8VariableStartIdx;
@@ -642,10 +636,10 @@ static const uint8_t v32MaximumEnginePeriodIdx =		v32MaximumVSSperiodIdx + 1;			
 static const uint8_t v32InjectorOpenDelayIdx =			v32MaximumEnginePeriodIdx + 1;			// injector settle time in timer0 cycles
 static const uint8_t v32InjectorValidMaxWidthIdx =		v32InjectorOpenDelayIdx + 1;			// maximum valid fuel injector pulse width in timer0 cycles
 #define nextAllowedValue v32InjectorValidMaxWidthIdx + 1
-#if defined(useCPUreading)
+#if defined(useCPUreading) || defined(useDebugCPUreading)
 static const uint8_t v32SystemCycleIdx =				nextAllowedValue;						// system timer tick count
 #define nextAllowedValue v32SystemCycleIdx + 1
-#endif // defined(useCPUreading)
+#endif // defined(useCPUreading) || defined(useDebugCPUreading)
 #if defined(useClockSupport)
 static const uint8_t v32ClockCycleIdx =					nextAllowedValue;						// software clock tick count
 #define nextAllowedValue v32ClockCycleIdx + 1
@@ -770,11 +764,11 @@ static const uint8_t m32FEvsSpeedQuantumIdx =			m32FEvsSpeedMinThresholdIdx + 1;
 #define nextAllowedValue m32FEvsSpeedQuantumIdx + 1
 
 #endif // defined(useBarFuelEconVsSpeed)
-#if defined(useCPUreading)
+#if defined(useCPUreading) || defined(useDebugCPUreading)
 static const uint8_t m32AvailableRAMidx =				nextAllowedValue;						// amount of remaining free RAM
 #define nextAllowedValue m32AvailableRAMidx + 1
 
-#endif // defined(useCPUreading)
+#endif // defined(useCPUreading) || defined(useDebugCPUreading)
 #if defined(useCPUreading) || defined(useDebugCPUreading)
 static const uint8_t m32CPUworkingLoopStartIdx =		nextAllowedValue;
 static const uint8_t m32CPUworkingMainStartIdx =		m32CPUworkingLoopStartIdx + 1;
@@ -1003,41 +997,6 @@ static const char terminalVariableLabels[] PROGMEM = {
 	"v8RTCyearIdx" tcEOS
 	"v8RTCcontrolIdx" tcEOS
 #endif // defined(useDS1307clock)
-#if defined(useOutputPins)
-	"v8OutputPinCurrentIdx" tcEOS
-	"v8OutputPinBitmask[0x00]" tcEOS
-	"v8OutputPinBitmask[0x01]" tcEOS
-	"v8OutputPinBitmask[0x02]" tcEOS
-	"v8OutputPinBitmask[0x03]" tcEOS
-	"v8OutputPinBitmask[0x04]" tcEOS
-	"v8OutputPinBitmask[0x05]" tcEOS
-	"v8OutputPinBitmask[0x06]" tcEOS
-	"v8OutputPinBitmask[0x07]" tcEOS
-	"v8OutputPinBitmask[0x08]" tcEOS
-	"v8OutputPinBitmask[0x09]" tcEOS
-	"v8OutputPinBitmask[0x0A]" tcEOS
-	"v8OutputPinBitmask[0x0B]" tcEOS
-	"v8OutputPinBitmask[0x0C]" tcEOS
-	"v8OutputPinBitmask[0x0D]" tcEOS
-	"v8OutputPinBitmask[0x0E]" tcEOS
-	"v8OutputPinBitmask[0x0F]" tcEOS
-	"v8OutputPinOCvalue[0x00]" tcEOS
-	"v8OutputPinOCvalue[0x01]" tcEOS
-	"v8OutputPinOCvalue[0x02]" tcEOS
-	"v8OutputPinOCvalue[0x03]" tcEOS
-	"v8OutputPinOCvalue[0x04]" tcEOS
-	"v8OutputPinOCvalue[0x05]" tcEOS
-	"v8OutputPinOCvalue[0x06]" tcEOS
-	"v8OutputPinOCvalue[0x07]" tcEOS
-	"v8OutputPinOCvalue[0x08]" tcEOS
-	"v8OutputPinOCvalue[0x09]" tcEOS
-	"v8OutputPinOCvalue[0x0A]" tcEOS
-	"v8OutputPinOCvalue[0x0B]" tcEOS
-	"v8OutputPinOCvalue[0x0C]" tcEOS
-	"v8OutputPinOCvalue[0x0D]" tcEOS
-	"v8OutputPinOCvalue[0x0E]" tcEOS
-	"v8OutputPinOCvalue[0x0F]" tcEOS
-#endif // defined(useOutputPins)
 
 	"m8MetricModeFlags" tcEOS
 	"m8EEPROMchangeStatus" tcEOS
@@ -1377,8 +1336,21 @@ static const uint8_t t0cResetInputActivityTimer =	0b01000000;
 static const uint8_t t0cResetOutputTimer =			0b00100000;
 static const uint8_t t0cReadRTC =					0b00010000;		// useRealTimeClockModule
 static const uint8_t t0cEnableJSONoutput =			0b00001000;		// useJSONoutput
-static const uint8_t t0cEnableOutputPin =			0b00000100;		// useOutputPins
 
+#if defined(useDebugTerminal)
+static const char timer0CommandFlagMarkers[] PROGMEM = {
+	" T0C" tcEOS
+	"reset" tcEOS
+	"input" tcEOS
+	"display" tcEOS
+	"rtc" tcEOS
+	"json" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 // these flags specifically tell the main program to do something (v8Timer0Status0Idx)
 // system timer0 sets flag, main program acknowledges by clearing flag
 static const uint8_t t0saTakeSample =				0b10000000;		// tells the main program to perform trip variable sampling
@@ -1387,10 +1359,23 @@ static const uint8_t t0saShowCursor =				0b00100000;
 static const uint8_t t0saDisplayDelayInit =			0b00010000;		// this is an exception in that main program actually sets this flag
 static const uint8_t t0saDisplayDelayActive =		0b00001000;
 static const uint8_t t0saOutputJSON =				0b00000100;		// useJSONoutput
-static const uint8_t t0saOutputPinEnabled =			0b00000010;		// useOutputPins
 
 static const uint8_t t0saDisplayDelayFlags =		(t0saDisplayDelayInit | t0saDisplayDelayActive);
 
+#if defined(useDebugTerminal)
+static const char timer0Status0FlagMarkers[] PROGMEM = {
+	" T0S0" tcEOS
+	"sample" tcEOS
+	"display" tcEOS
+	"cursor" tcEOS
+	"delayInit" tcEOS
+	"delay" tcEOS
+	"json" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 // these flags specifically tell the main program to do something (v8Timer0Status1Idx)
 // system timer0 sets flag, main program acknowledges by clearing flag
 static const uint8_t t0sbSampleBLEfriend =			0b10000000;		// useBluetoothAdaFruitSPI
@@ -1400,6 +1385,20 @@ static const uint8_t t0sbResetFEvsTimeTrip =		0b00010000;		// useBarFuelEconVsTi
 static const uint8_t t0sbAccelTestFlag =			0b00001000;		// useDragRaceFunction
 static const uint8_t t0sbCoastdownTestFlag =		0b00000100;		// useCoastDownCalculator
 
+#if defined(useDebugTerminal)
+static const char timer0Status1FlagMarkers[] PROGMEM = {
+	" T0S1" tcEOS
+	"ble" tcEOS
+	"rtc" tcEOS
+	"rtcErr" tcEOS
+	"fevt" tcEOS
+	"accel" tcEOS
+	"coast" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 // these status flags inform the main program about MPGuino awake state (v8AwakeIdx)
 static const uint8_t aAwakeOnInjector =				0b10000000;
 static const uint8_t aAwakeOnVSS =					0b01000000;
@@ -1410,6 +1409,20 @@ static const uint8_t aAwakeVehicleMoving =			0b00001000;
 static const uint8_t aAwake =						(aAwakeOnInjector | aAwakeOnVSS | aAwakeOnInput);
 static const uint8_t aAwakeOnVehicle =				(aAwakeOnInjector | aAwakeOnVSS | aAwakeEngineRunning | aAwakeVehicleMoving);
 
+#if defined(useDebugTerminal)
+static const char awakeFlagMarkers[] PROGMEM = {
+	" AW" tcEOS
+	"inj" tcEOS
+	"vss" tcEOS
+	"input" tcEOS
+	"eng" tcEOS
+	"move" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 // these status flags inform the main program about MPGuino sensor activity (v8ActivityIdx, v8ActivityChangeIdx)
 static const uint8_t afEngineOffFlag =				0b10000000;
 static const uint8_t afVehicleStoppedFlag =			0b01000000;
@@ -1419,6 +1432,20 @@ static const uint8_t afActivityTimeoutFlag =		0b00001000;
 static const uint8_t afVehicleIdleFlag =			0b00000100;
 static const uint8_t afVehicleEOCflag =				0b00000010;
 
+#if defined(useDebugTerminal)
+static const char activityFlagMarkers[] PROGMEM = {
+	"" tcEOS
+	"engOff" tcEOS
+	"stopped" tcEOS
+	"input" tcEOS
+	"park" tcEOS
+	"timeout" tcEOS
+	"idle" tcEOS
+	"eoc" tcEOS
+	"0" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 static const uint8_t afValidFlags =					(afEngineOffFlag | afVehicleStoppedFlag | afParkFlag | afUserInputFlag | afActivityTimeoutFlag);
 static const uint8_t afInputCheckFlags =			(afEngineOffFlag | afVehicleStoppedFlag | afUserInputFlag);
 static const uint8_t afActivityCheckFlags =			(afEngineOffFlag | afVehicleStoppedFlag | afUserInputFlag | afParkFlag);
@@ -1434,6 +1461,20 @@ static const uint8_t dInjectorReadInProgress =		0b00001000;
 
 static const uint8_t dGoodEngineRun =				(dGoodInjectorOpen | dGoodInjectorClose | dGoodInjectorOpenPeriod | dInjectorReadInProgress | dGoodInjectorRead);
 
+#if defined(useDebugTerminal)
+static const char dirtyInjectorFlagMarkers[] PROGMEM = {
+	" INJ" tcEOS
+	"open" tcEOS
+	"close" tcEOS
+	"period" tcEOS
+	"read" tcEOS
+	"busy" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 // these status flags communicate instantaneous vehicle status between the sensor interrupts and the system timer0 interrupt (v8DirtyVSSIdx)
 static const uint8_t dGoodVSSsignal =				0b10000000;
 static const uint8_t dVSSreadInProgress =			0b01000000;
@@ -1441,6 +1482,20 @@ static const uint8_t dGoodVSSpulse =				0b00100000;
 
 static const uint8_t dGoodVehicleMotion =			(dGoodVSSsignal | dVSSreadInProgress | dGoodVSSpulse);
 
+#if defined(useDebugTerminal)
+static const char dirtyVSSflagMarkers[] PROGMEM = {
+	" VSS" tcEOS
+	"signal" tcEOS
+	"busy" tcEOS
+	"pulse" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+	"0" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 static const uint8_t internalOutputButton =			0b10000000;
 static const uint8_t internalProcessButton =		0b01000000;
 static const uint8_t internalButtonValid =			0b00100000;

--- a/mpguino_tav/heart.ino
+++ b/mpguino_tav/heart.ino
@@ -119,41 +119,6 @@ ISR( TIMER0_OVF_vect ) // system timer interrupt handler
 #endif // defined(useRealTimeClockModule)
 	}
 
-#if defined(useOutputPins)
-	if (v08(v8Timer0CommandIdx) & t0cEnableOutputPin)
-	{
-
-		if ((v08(v8Timer0Status0Idx) & t0saOutputPinEnabled) == 0)
-		{
-
-			v08(v8Timer0Status0Idx) |= (t0saOutputPinEnabled);
-
-			DDRL = 0xFF;
-
-		}
-
-		PORTL = v08(v08(v8OutputPinCurrentIdx));
-
-		v08(v8OutputPinCurrentIdx)++;
-		if (v08(v8OutputPinCurrentIdx) == v8OutputPinOCvalue) v08(v8OutputPinCurrentIdx) = v8OutputPinBitmask;
-
-	}
-	else
-	{
-
-		if (v08(v8Timer0Status0Idx) & t0saOutputPinEnabled)
-		{
-
-			v08(v8Timer0Status0Idx) &= ~(t0saOutputPinEnabled);
-
-			PORTL = 0;
-			DDRL = 0x00;
-
-		}
-
-	}
-
-#endif // defined(useOutputPins)
 	if (v08(v8AwakeIdx) & aAwakeOnInjector) // if MPGuino is awake on detected fuel injector event
 	{
 
@@ -1891,7 +1856,7 @@ static void heart::initCore(void)
 	TIFR0 |= (_BV(OCF0B) | _BV(OCF0A) | _BV(TOV0));
 
 	// disable digital inputs for all ADC capable pins to reduce power consumption
-	DIDR0 |= ((ADC7D) | _BV(ADC6D) | _BV(ADC5D) | _BV(ADC4D) | _BV(ADC1D) | _BV(ADC0D));
+	DIDR0 |= (_BV(ADC7D) | _BV(ADC6D) | _BV(ADC5D) | _BV(ADC4D) | _BV(ADC1D) | _BV(ADC0D));
 	DIDR1 |= _BV(AIN0D);
 	DIDR2 |= (_BV(ADC13D) | _BV(ADC12D) | _BV(ADC11D) | _BV(ADC10D) | _BV(ADC9D) | _BV(ADC8D));
 
@@ -2030,20 +1995,6 @@ static void heart::initCore(void)
 	v08(v8Timer1CommandIdx) = (t1cResetTimer);
 #endif // defined(useTimer1Interrupt)
 
-#if defined(useOutputPins)
-	v08(v8OutputPinCurrentIdx) = v8OutputPinBitmask;
-
-	for (uint8_t i = 7; i < 8; i--)
-	{
-
-		v08(v8OutputPinBitmask + i * 2) = (1 << i);
-		v08(v8OutputPinOCvalue + i * 2) = 0;
-		v08(v8OutputPinBitmask + i * 2 + 1) = 0;
-		v08(v8OutputPinOCvalue + i * 2 + 1) = 128;
-
-	}
-
-#endif // defined(useOutputPins)
 	SREG = oldSREG; // restore interrupt flag status
 
 }

--- a/mpguino_tav/m_serial.ino
+++ b/mpguino_tav/m_serial.ino
@@ -84,7 +84,7 @@ static void serial0::chrOut(uint8_t chr)
 	SREG = oldSREG; // restore interrupt flag status
 
 #else // defined(useBufferedSerial0Port)
-	while ((UCSR0A & (1 << UDRE0)) == 0) heart::sleepModeIdle(LEDdebugUARTin | LEDdebugUART0); // go perform idle sleep mode
+	while ((UCSR0A & (1 << UDRE0)) == 0) heart::sleepModeIdle(LEDdebugUARTout | LEDdebugUART0); // go perform idle sleep mode
 
 	UCSR0A &= ~(1 << TXC0); // clear transmit complete flag
 	UDR0 = chr; //send the data

--- a/mpguino_tav/mpguino_tav.ino
+++ b/mpguino_tav/mpguino_tav.ino
@@ -438,6 +438,18 @@ Logging Output / Debug Monitor I/O
 
 #define tcEOS		"\0"
 #define tcEOSCR		"\r"
+#define tcSPC		"\x01"			// space-run sentinel: followed by count byte, expands to that many spaces
+#define tcSP3		tcSPC "\x03"
+#define tcSP4		tcSPC "\x04"
+#define tcSP6		tcSPC "\x06"
+#define tcSP7		tcSPC "\x07"
+#define tcSP10		tcSPC "\x0a"
+#define tcSP11		tcSPC "\x0b"
+#define tcSP15		tcSPC "\x0f"
+#define tcSP16		tcSPC "\x10"
+#define tcSP17		tcSPC "\x11"
+#define tcSP18		tcSPC "\x12"
+#define tcSP19		tcSPC "\x13"
 #define tcOMOFF		"\xEB"
 #define tcOTOG		"\xEC"
 #define tcOON		"\xED"

--- a/mpguino_tav/parameters.h
+++ b/mpguino_tav/parameters.h
@@ -214,30 +214,31 @@ static const uint8_t pSizeLCDcolor =					3;					// pLCDcolorIdx
 #endif // defined(useAdafruitRGBLCDdisplay)
 #endif // defined(useLCDoutput)
 #if defined(useFuelCost)
-static const uint8_t pSizeFuelUnitCost =				24;
+static const uint8_t pSizeFuelUnitCost =				24;					// pCostPerQuantity
 #endif // defined(useFuelCost)
 #if defined(useOutputPins)
-static const uint8_t pSizeOutputPin1Mode =				3;
-static const uint8_t pSizeOutputPin2Mode =				3;
+static const uint8_t pSizeOutputPin1Mode =				4;					// pOutputPin1Mode
+static const uint8_t pSizeOutputPin2Mode =				4;					// pOutputPin2Mode
+static const uint8_t pSizeOutputPinMaxFuelEconomy =		24;					// pOutputPinMaxFuelEconomy
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
-static const uint8_t pSizeVoltageOffset =				12;
+static const uint8_t pSizeVoltageOffset =				12;					// pVoltageOffset
 #endif // defined(useAlternatorVoltage)
 #if defined(useDataLoggingOutput)
-static const uint8_t pSizeSerialDataLogging =			1;
+static const uint8_t pSizeSerialDataLogging =			1;					// pSerialDataLoggingIdx
 #endif // defined(useDataLoggingOutput)
 #if defined(useJSONoutput)
-static const uint8_t pSizeJSONoutput =					1;
+static const uint8_t pSizeJSONoutput =					1;					// pJSONoutputIdx
 #endif // defined(useJSONoutput)
 #if defined(useBluetooth)
-static const uint8_t pSizeBluetoothOutput =				1;
+static const uint8_t pSizeBluetoothOutput =				1;					// pBluetoothOutputIdx
 #endif // defined(useBluetooth)
 #if defined(useBarFuelEconVsTime)
-static const uint8_t pSizeFEvsTime =					16;
+static const uint8_t pSizeFEvsTime =					16;					// pFEvsTimeIdx
 #endif // defined(useBarFuelEconVsTime)
 #if defined(useBarFuelEconVsSpeed)
-static const uint8_t pSizeBarLowSpeedCutoff =			24;
-static const uint8_t pSizeBarSpeedQuantumIdx =			24;
+static const uint8_t pSizeBarLowSpeedCutoff =			24;					// pBarLowSpeedCutoffIdx
+static const uint8_t pSizeBarSpeedQuantumIdx =			24;					// pBarSpeedQuantumIdx
 #endif // defined(useBarFuelEconVsSpeed)
 #if defined(useFuelPressure)
 static const uint8_t pSizeSysFuelPressure =				32;					// pSysFuelPressureIdx
@@ -371,37 +372,38 @@ static const uint16_t pAddressLCDcolor =					nextAllowedValue;	// pLCDcolorIdx
 #endif // defined(useAdafruitRGBLCDdisplay)
 #endif // defined(useLCDoutput)
 #if defined(useFuelCost)
-static const uint16_t pAddressFuelUnitCost =				nextAllowedValue;
+static const uint16_t pAddressFuelUnitCost =				nextAllowedValue;	// pCostPerQuantity
 #define nextAllowedValue pAddressFuelUnitCost + byteSize(pSizeFuelUnitCost)
 #endif // defined(useFuelCost)
 #if defined(useOutputPins)
-static const uint16_t pAddressOutputPin1Mode =				nextAllowedValue;
-static const uint16_t pAddressOutputPin2Mode =				pAddressOutputPin1Mode + byteSize(pSizeOutputPin1Mode);
-#define nextAllowedValue pAddressOutputPin2Mode + byteSize(pSizeOutputPin2Mode)
+static const uint16_t pAddressOutputPin1Mode =				nextAllowedValue;	// pOutputPin1Mode
+static const uint16_t pAddressOutputPin2Mode =				pAddressOutputPin1Mode + byteSize(pSizeOutputPin1Mode);	// pOutputPin2Mode
+static const uint16_t pAddressOutputPinMaxFuelEconomy =		pAddressOutputPin2Mode + byteSize(pSizeOutputPin2Mode);	// pOutputPinMaxFuelEconomy
+#define nextAllowedValue pAddressOutputPinMaxFuelEconomy + byteSize(pSizeOutputPinMaxFuelEconomy)
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
-static const uint16_t pAddressVoltageOffset =				nextAllowedValue;
+static const uint16_t pAddressVoltageOffset =				nextAllowedValue;	// pVoltageOffset
 #define nextAllowedValue pAddressVoltageOffset + byteSize(pSizeVoltageOffset)
 #endif // defined(useAlternatorVoltage)
 #if defined(useDataLoggingOutput)
-static const uint16_t pAddressSerialDataLogging =			nextAllowedValue;
+static const uint16_t pAddressSerialDataLogging =			nextAllowedValue;	// pSerialDataLoggingIdx
 #define nextAllowedValue pAddressSerialDataLogging + byteSize(pSizeSerialDataLogging)
 #endif // defined(useDataLoggingOutput)
 #if defined(useJSONoutput)
-static const uint16_t pAddressJSONoutput =					nextAllowedValue;
+static const uint16_t pAddressJSONoutput =					nextAllowedValue;	// pJSONoutputIdx
 #define nextAllowedValue pAddressJSONoutput + byteSize(pSizeJSONoutput)
 #endif // defined(useJSONoutput)
 #if defined(useBluetooth)
-static const uint16_t pAddressBluetoothOutput =				nextAllowedValue;
+static const uint16_t pAddressBluetoothOutput =				nextAllowedValue;	// pBluetoothOutputIdx
 #define nextAllowedValue pAddressBluetoothOutput + byteSize(pSizeBluetoothOutput)
 #endif // defined(useBluetooth)
 #if defined(useBarFuelEconVsTime)
-static const uint16_t pAddressFEvsTime =					nextAllowedValue;
+static const uint16_t pAddressFEvsTime =					nextAllowedValue;	// pFEvsTimeIdx
 #define nextAllowedValue pAddressFEvsTime + byteSize(pSizeFEvsTime)
 #endif // defined(useBarFuelEconVsTime)
 #if defined(useBarFuelEconVsSpeed)
-static const uint16_t pAddressBarLowSpeedCutoff =			nextAllowedValue;
-static const uint16_t pAddressBarSpeedQuantumIdx =			pAddressBarLowSpeedCutoff + byteSize(pSizeBarLowSpeedCutoff);
+static const uint16_t pAddressBarLowSpeedCutoff =			nextAllowedValue;	// pBarLowSpeedCutoffIdx
+static const uint16_t pAddressBarSpeedQuantumIdx =			pAddressBarLowSpeedCutoff + byteSize(pSizeBarLowSpeedCutoff);	// pBarSpeedQuantumIdx
 #define nextAllowedValue pAddressBarSpeedQuantumIdx + byteSize(pSizeBarSpeedQuantumIdx)
 #endif // defined(useBarFuelEconVsSpeed)
 #if defined(useFuelPressure)
@@ -575,7 +577,8 @@ static const uint8_t pCostPerQuantity =					nextAllowedValue;
 #if defined(useOutputPins)
 static const uint8_t pOutputPin1Mode =					nextAllowedValue;
 static const uint8_t pOutputPin2Mode =					pOutputPin1Mode + 1;
-#define nextAllowedValue pOutputPin2Mode + 1
+static const uint8_t pOutputPinMaxFuelEconomy =			pOutputPin2Mode + 1;
+#define nextAllowedValue pOutputPinMaxFuelEconomy + 1
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 static const uint8_t pVoltageOffset =					nextAllowedValue;
@@ -783,6 +786,7 @@ static const char terminalParameterNames[] PROGMEM = {
 #if defined(useOutputPins)
 	"pOutputPin1Mode" tcEOS
 	"pOutputPin2Mode" tcEOS
+	"pOutputPinMaxFuelEconomy" tcEOS
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 	"pVoltageOffset" tcEOS
@@ -1143,6 +1147,7 @@ static const uint8_t paramsLength[(uint16_t)(eePtrStorageEnd)] PROGMEM = {
 #if defined(useOutputPins)
 	(pSizeOutputPin1Mode & 0x07),												// Output Pin 1 mode
 	(pSizeOutputPin2Mode & 0x07),												// Output Pin 2 mode
+	(pSizeOutputPinMaxFuelEconomy & 0x07),										// Output pin max fuel economy
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 	(pSizeVoltageOffset & 0x07),												// diode offset from V(alternator)
@@ -1290,11 +1295,12 @@ static const uint16_t paramAddrs[(uint16_t)(eePtrStorageEnd)] PROGMEM = {
 #endif // defined(useAdafruitRGBLCDdisplay)
 #endif // defined(useLCDoutput)
 #if defined(useFuelCost)
-	pAddressFuelUnitCost,				// Price per unit volume of fuel
+	pAddressFuelUnitCost,				// pCostPerQuantity
 #endif // defined(useFuelCost)
 #if defined(useOutputPins)
-	pAddressOutputPin1Mode,				// Output Pin 1 mode
-	pAddressOutputPin2Mode,				// Output Pin 2 mode
+	pAddressOutputPin1Mode,				// pOutputPin1Mode
+	pAddressOutputPin2Mode,				// pOutputPin2Mode
+	pAddressOutputPinMaxFuelEconomy,	// Output pin max fuel economy
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 	pAddressVoltageOffset,				// diode offset from V(alternator)
@@ -1450,6 +1456,7 @@ static const uint32_t params[(uint16_t)(pSettingsIdxLen)] PROGMEM = {
 #if defined(useOutputPins)
 	0,					// Output pin 1 mode
 	0,					// Output pin 2 mode
+	50000,				// Output pin max fuel economy (50 MPG * 1000 SAE, or equivalent KPL * 1000 in metric)
 #endif // defined(useOutputPins)
 #if defined(useAlternatorVoltage)
 	700,				// diode offset from V(alternator) (via meelis11)

--- a/mpguino_tav/parameters.ino
+++ b/mpguino_tav/parameters.ino
@@ -519,6 +519,22 @@ static const uint8_t prgmDoEEPROMmetricConversion[] PROGMEM = {
 	instrStRegEEPROM, 0x02, pRefFuelPressureIdx,
 
 #endif // useCalculatedFuelFactor
+#if defined(useOutputPins)
+	instrLdRegRdOnlyMetric, 0x12, idxNumerDistance,		// convert output pin max FE value - distance part (miles <-> km)
+	instrLdRegRdOnlyMetric, 0x21, idxDenomDistance,
+	instrMul2byEEPROM, pOutputPinMaxFuelEconomy,
+	instrDiv2by1,
+	instrAdjustQuotient,
+	instrStRegEEPROM, 0x02, pOutputPinMaxFuelEconomy,
+
+	instrLdRegRdOnlyMetric, 0x12, idxDenomVolume,		// convert output pin max FE value - inverted volume part (per gallon <-> per liter)
+	instrLdRegRdOnlyMetric, 0x21, idxNumerVolume,
+	instrMul2byEEPROM, pOutputPinMaxFuelEconomy,
+	instrDiv2by1,
+	instrAdjustQuotient,
+	instrStRegEEPROM, 0x02, pOutputPinMaxFuelEconomy,
+
+#endif // defined(useOutputPins)
 	instrDone											// return to caller
 };
 

--- a/mpguino_tav/sweet64.h
+++ b/mpguino_tav/sweet64.h
@@ -18,6 +18,7 @@ namespace SWEET64 /* 64-bit pseudo-processor section prototype */
 {
 
 	static s64pc_t makeProgmemProgram(s64prgm_ptr_t ptr);
+	static s64pc_t makeRAMprogram(uint8_t * ptr);
 #if defined(useSWEET64RAMprograms)
 	static uint8_t readProgramRAM(uint8_t addr);
 	static void writeProgramRAM(uint8_t addr, uint8_t value);
@@ -25,7 +26,6 @@ namespace SWEET64 /* 64-bit pseudo-processor section prototype */
 	static uint16_t getProgramRAMsize(void);
 	static uint8_t * getProgramRAMaddress(uint8_t addr);
 	static uint8_t getProgramRAMoffset(uint8_t * ptr);
-	static s64pc_t makeRAMprogram(uint8_t * ptr);
 	static s64pc_t makeRAMprogram(uint8_t addr);
 	static void enableProgramRAMoverride(uint8_t prgmIdx, uint8_t ramAddr);
 	static void disableProgramRAMoverride(void);
@@ -217,6 +217,20 @@ static const uint8_t SWEET64traceFlag =			0b10000000;
 
 static const uint8_t SWEET64traceFlagGroup =	SWEET64traceCommandFlag | SWEET64traceFlag;
 
+#if defined(useDebugTerminal)
+static const char SWEET64processorFlagMarkers[] PROGMEM = {
+	" S64status" tcEOS
+	"T" tcEOS
+	"TC" tcEOS
+	"TS" tcEOS
+	"E" tcEOS
+	"OVF" tcEOS
+	"N" tcEOS
+	"Z" tcEOS
+	"C" tcEOS
+};
+
+#endif // defined(useDebugTerminal)
 #define nextAllowedValue 0
 static const uint8_t s64reg64_1 =		nextAllowedValue;		// general purpose
 static const uint8_t s64reg64_2 =		s64reg64_1 + 1;			// output value / general purpose
@@ -234,7 +248,11 @@ static const uint8_t s64reg64count =	nextAllowedValue;
 
 static uint64_t s64reg[(uint16_t)(s64reg64count)];
 
-static s64pc_t s64stack[16];
+static const uint8_t s64stackSize =		16;
+static s64pc_t s64stack[(uint16_t)(s64stackSize)];
+#if defined(useDebugTerminalSWEET64)
+static uint8_t s64callIndexStack[s64stackSize + 1];
+#endif // defined(useDebugTerminalSWEET64)
 
 #define nextAllowedValue 0
 static const uint8_t s64oprRegXY =			nextAllowedValue;

--- a/mpguino_tav/sweet64.ino
+++ b/mpguino_tav/sweet64.ino
@@ -1427,8 +1427,8 @@ static void SWEET64::copy64(union union_64 * an, union union_64 * ann) // an = a
 		"	ld	__tmp_reg__, %a1+	\n"
 		"	st	%a0+, __tmp_reg__	\n"
 
-		: "+e" (an)
-		: "e" (ann)
+		: "+e" (an), "+e" (ann)
+		:
 	);
 #else // defined(useAssemblyLanguage)
 	for (uint8_t x = 0; x < 4; x++) an->u16[(uint16_t)(x)] = ann->u16[(uint16_t)(x)];
@@ -1758,7 +1758,11 @@ static void SWEET64::registerTest64(union union_64 * an)
 
 }
 
+#if defined(useAssemblyLanguage)
+static void __attribute__((noinline)) SWEET64::mult64(uint64_t * prgmReg64)
+#else // defined(useAssemblyLanguage)
 static void SWEET64::mult64(uint64_t * prgmReg64)
+#endif // defined(useAssemblyLanguage)
 {
 
 	union union_64 * an = (union union_64 *)(&prgmReg64[(uint16_t)(s64reg64_2)]);	// multiplier in an, result to an
@@ -1932,7 +1936,11 @@ static void SWEET64::mult64(uint64_t * prgmReg64)
 #endif // defined(useAssemblyLanguage)
 }
 
+#if defined(useAssemblyLanguage)
+static void __attribute__((noinline)) SWEET64::div64(uint64_t * prgmReg64) // uses algorithm for non-restoring hardware division
+#else // defined(useAssemblyLanguage)
 static void SWEET64::div64(uint64_t * prgmReg64) // uses algorithm for non-restoring hardware division
+#endif // defined(useAssemblyLanguage)
 {
 
 	union union_64 * ann = (union union_64 *)(&prgmReg64[(uint16_t)(s64reg64_1)]);	// remainder in ann
@@ -1987,6 +1995,8 @@ static void SWEET64::div64(uint64_t * prgmReg64) // uses algorithm for non-resto
 		"	st	x+, r25				\n"		// store overflow value into remainder and quotient
 		"	dec	r24					\n"
 		"	brne	d64_ovfl%=		\n"
+		"	subi	r26, 16			\n"		// restore X reg to original ann value
+		"	sbci	r27, 0			\n"
 		"	rjmp	d64_exit%=		\n"		// go exit
 
 		"d64_cont1%=:				\n"

--- a/mpguino_tav/sweet64.ino
+++ b/mpguino_tav/sweet64.ino
@@ -33,20 +33,22 @@ static s64pc_t SWEET64::makeProgmemProgram(s64prgm_ptr_t ptr)
 
 }
 
-#if defined(useSWEET64RAMprograms)
 static s64pc_t SWEET64::makeRAMprogram(uint8_t * ptr)
 {
 
 	s64pc_t prgmPtr;
 	
 	prgmPtr.ptr = 0;
+#if defined(useSWEET64RAMprograms)
 	prgmPtr.ram_ptr = ptr;
 	prgmPtr.source = s64srcRAM;
+#endif // defined(useSWEET64RAMprograms)
 
 	return prgmPtr;
 
 }
 
+#if defined(useSWEET64RAMprograms)
 static uint8_t SWEET64::readProgramRAM(uint8_t addr)
 {
 
@@ -152,7 +154,7 @@ static uint8_t SWEET64::isProgramValid(s64pc_t prgmPtr)
 
 	}
 #else // defined(useSWEET64RAMprograms)
-	return prgmPtr.ptr;
+	return (prgmPtr.ptr != 0);
 #endif // defined(useSWEET64RAMprograms)
 
 }
@@ -1321,7 +1323,7 @@ static void SWEET64::executeInstruction(union union_32 * instrLWord, s64pc_t &pr
 					break;
 
 				case e27:	// call
-					if (prgmReg8[(uint16_t)(si64reg8spnt)] > 15)
+					if (prgmReg8[(uint16_t)(si64reg8spnt)] >= s64stackSize)
 					{
 
 						setProgramError(prgmReg8, s64errStackOverflow);
@@ -1329,6 +1331,9 @@ static void SWEET64::executeInstruction(union union_32 * instrLWord, s64pc_t &pr
 						break;
 
 					}
+#if defined(useDebugTerminalSWEET64)
+					s64callIndexStack[(uint16_t)(prgmReg8[(uint16_t)(si64reg8spnt)])] = extra;
+#endif // defined(useDebugTerminalSWEET64)
 					prgmStack[(uint16_t)(prgmReg8[(uint16_t)(si64reg8spnt)]++)] = prgmPtr;
 				case e28:	// jump
 					prgmPtr = getProgramPC(extra);

--- a/mpguino_tav/text.ino
+++ b/mpguino_tav/text.ino
@@ -2,7 +2,7 @@
 
 static const uint8_t prgmRoundOffNumber[] PROGMEM = {
 	instrTestReg, 0x02,									// test register 2
-	instrBranchIfOverflow, 23,							// if register 2 has overflow value, exit
+	instrBranchIfOverflow, 21,							// if register 2 has overflow value, exit
 	instrCmpIndex, 2,									// check if 3 or more right hand digits were specified
 	instrBranchIfGT, 17,								// if so, just exit
 	instrBranchIfE, 12,									// if 2 right hand digits were specified, round to nearest 100th
@@ -234,7 +234,21 @@ static void text::stringOut(uint8_t devIdx, const char * str, uint8_t strIdx)
 static void text::stringOut(uint8_t devIdx, const char * str)
 {
 
-	while (charOut(devIdx, pgm_read_byte(str++))) ;
+	uint8_t chr;
+
+	while ((chr = pgm_read_byte(str++)))
+	{
+
+		if (chr == '\x01') // space-run: next byte is count
+		{
+
+			uint8_t count = pgm_read_byte(str++);
+			while (count--) charOut(devIdx, ' ');
+
+		}
+		else if (!charOut(devIdx, chr)) break;
+
+	}
 
 }
 


### PR DESCRIPTION
## Summary

- **SWEET64 RAM assembler / mini-assembler**: full support for writing and running SWEET64 programs in RAM, including assembler, disassembler, and label resolution
- **mega2560 far pointer fix**: corrected far pointer handling for SWEET64 program access on ATmega2560
- **Inline asm constraint bugfixes**: fixed constraint bugs in `copy64`, `mult64`, `div64`
- **Debug monitor rewrites**: state machine overhaul for robustness and efficiency; added trace/list functionality, SWEET64 error muting (`N` command), and improved `dumpSWEET64information` (separate sections for call stack, 64-bit registers, 8-bit registers with optional labels)
- **Generalized status flag output**: replaced per-group switch/case with table-driven `outputFlagStatusGroup()` (~600 bytes saved); PROGMEM flag marker tables for all system status bytes and SWEET64 processor flags
- **TFT board support (`useMPGuinoColourTouch` / abbalooga)**: strip LCD character-cell features (big chars, bar graphs, LCD fonts/graphics, contrast/brightness, screen editor) in `useTFToutput` block so TFT builds are clean
- **Documentation**: added user manual, SWEET64 developer manual, historical archive

## Test plan

- [x] Compile for ATmega328P with `useAtMega328debugMonitor` — verify no LCD/button symbols referenced
- [ ] Compile for ATmega2560 with `useMPGuinoColourTouch` — verify LCD character-cell features stripped, TFT/touch retained
- [x] Compile for ATmega2560 with `useArduinoMega2560` + LCD config — verify normal LCD build unaffected
- [x] Exercise debug terminal: status flag output, SWEET64 dump, mute toggle (`N`), trip function list (`L`)
- [x] Verify SWEET64 RAM program assemble/run/disassemble round-trip on mega2560